### PR TITLE
Remove mentions of Python 2.5 and 'from __future__ import with'

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -386,10 +386,7 @@ We've seen one way of controlling precision and rounding mode, via the
 ``context`` keyword argument.  There's another way that's often more
 convenient, especially when a single context change is supposed to
 apply to multiple operations: contexts can be used directly in Python
-``with`` statements.  Note: if you're using Python 2.5, you'll need
-to enable with statements with:
-
-   >>> from __future__ import with_statement
+``with`` statements.
 
 For example, here we compute high-precision upper and lower-bounds for
 the thousandth harmonic number:
@@ -631,15 +628,10 @@ deviations from expected behaviour.
   otherwise.  None of these conversions is affected by the current
   context.
 
-* :class:`BigFloat` instances are hashable.  For Python 2.6 and later,
-  the hash function obeys the rule that objects that compare equal
-  should hash equal; in particular, if ``x == n`` for some
-  :class:`BigFloat` instance ``x`` and some Python int or long ``n``
-  then ``hash(x) == hash(n)``, and similarly for floats.  In Python
-  2.5, there are some rare cases where ``x == n`` does not imply
-  ``hash(x) == hash(n)``.  For that reason it's inadvisable to mix
-  integers and BigFloat instances in a set, or to use both integers
-  and BigFloat instances as keys in the same dictionary.
+* :class:`BigFloat` instances are hashable.  The hash function obeys the rule
+  that objects that compare equal should hash equal; in particular, if ``x ==
+  n`` for some :class:`BigFloat` instance ``x`` and some Python int or long
+  ``n`` then ``hash(x) == hash(n)``, and similarly for floats.
 
 
 The Context class

--- a/examples/contfrac.py
+++ b/examples/contfrac.py
@@ -15,8 +15,6 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with the bigfloat module.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import with_statement
-
 """
 The documentation for mpfr_get_str, for converting a precision n
 number into a base b string, says:

--- a/examples/lanczos_coeffs.py
+++ b/examples/lanczos_coeffs.py
@@ -67,7 +67,6 @@
 
 
 from __future__ import division
-from __future__ import with_statement
 from math import factorial
 import bigfloat
 from bigfloat import exp


### PR DESCRIPTION
Also remove mention of hash compatibility issues in Python 2.5.
