### PR TITLE
Add bigfloat.notequal function; use it in BigFloat.__ne__.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,8 @@ Library
 
 - Add bigfloat.__version__ (#46).
 
+- Add bigfloat.notequal.
+
 
 What's new in bigfloat 0.3.0?
 =============================

--- a/bigfloat/__init__.py
+++ b/bigfloat/__init__.py
@@ -74,7 +74,7 @@ __all__ = [
     # 5.6 Comparison functions
     'cmp', 'cmpabs', 'is_nan', 'is_inf', 'is_finite', 'is_zero', 'is_regular',
     'sgn', 'greater', 'greaterequal', 'less', 'lessequal', 'equal',
-    'lessgreater', 'unordered',
+    'notequal', 'lessgreater', 'unordered',
 
     # 5.7 Special Functions
     'log', 'log2', 'log10', 'exp', 'exp2', 'exp10',
@@ -142,7 +142,8 @@ from bigfloat.core import (
 
     # 5.6 Comparison Functions
     cmp, cmpabs, is_nan, is_inf, is_finite, is_zero, is_regular, sgn,
-    greater, greaterequal, less, lessequal, equal, lessgreater, unordered,
+    greater, greaterequal, less, lessequal, equal, notequal, lessgreater,
+    unordered,
 
     # 5.7 Special Functions
     log, log2, log10, exp, exp2, exp10,

--- a/bigfloat/core.py
+++ b/bigfloat/core.py
@@ -740,10 +740,6 @@ class BigFloat(mpfr.Mpfr_t):
                 n = int(digits, 16) * _builtin_pow(2 ** 60, -e, 2 ** 64 - 1)
             return hash(-n if negative else n)
 
-        # != is automatically inferred from == for Python 3.
-        def __ne__(self, other):
-            return not (self == other)
-
         def __nonzero__(self):
             return not is_zero(self)
 
@@ -1368,6 +1364,18 @@ def equal(x, y):
     x = BigFloat._implicit_convert(x)
     y = BigFloat._implicit_convert(y)
     return mpfr.mpfr_equal_p(x, y)
+
+
+def notequal(x, y):
+    """
+    Return True if x != y and False otherwise.
+
+    This function returns True whenever x and/or y is a NaN.
+
+    """
+    x = BigFloat._implicit_convert(x)
+    y = BigFloat._implicit_convert(y)
+    return not mpfr.mpfr_equal_p(x, y)
 
 
 def lessgreater(x, y):
@@ -2463,6 +2471,7 @@ if (mpfr.MPFR_VERSION_MAJOR, mpfr.MPFR_VERSION_MINOR) >= (2, 4):
 
 # comparisons
 BigFloat.__eq__ = _binop(equal)
+BigFloat.__ne__ = _binop(notequal)
 BigFloat.__le__ = _binop(lessequal)
 BigFloat.__lt__ = _binop(less)
 BigFloat.__ge__ = _binop(greaterequal)

--- a/bigfloat/test/test_bigfloat.py
+++ b/bigfloat/test/test_bigfloat.py
@@ -70,7 +70,7 @@ from bigfloat import (
 
     # 5.6 Comparison Functions
     cmp, cmpabs, is_nan, is_inf, is_finite, is_zero, is_regular, sgn,
-    lessgreater, unordered,
+    notequal, lessgreater, unordered,
 
     # 5.7 Special Functions
     exp,
@@ -409,6 +409,7 @@ class BigFloatTests(unittest.TestCase):
             self.assertIs(x > y, False)
             self.assertIs(x >= y, False)
             self.assertIs(x == y, False)
+            self.assertIs(notequal(x, y), True)
             self.assertIs(lessgreater(x, y), True)
             self.assertIs(unordered(x, y), False)
 
@@ -419,6 +420,7 @@ class BigFloatTests(unittest.TestCase):
             self.assertIs(x < y, False)
             self.assertIs(x > y, False)
             self.assertIs(x != y, False)
+            self.assertIs(notequal(x, y), False)
             self.assertIs(lessgreater(x, y), False)
             self.assertIs(unordered(x, y), False)
 
@@ -429,6 +431,7 @@ class BigFloatTests(unittest.TestCase):
             self.assertIs(x < y, False)
             self.assertIs(x <= y, False)
             self.assertIs(x == y, False)
+            self.assertIs(notequal(x, y), True)
             self.assertIs(lessgreater(x, y), True)
             self.assertIs(unordered(x, y), False)
 
@@ -439,6 +442,7 @@ class BigFloatTests(unittest.TestCase):
             self.assertIs(x >= y, False)
             self.assertIs(x == y, False)
             self.assertIs(x != y, True)
+            self.assertIs(notequal(x, y), True)
             self.assertIs(lessgreater(x, y), False)
             self.assertIs(unordered(x, y), True)
 

--- a/docs/source/reference/index.rst
+++ b/docs/source/reference/index.rst
@@ -520,6 +520,7 @@ comparison operators.
 .. autofunction:: less
 .. autofunction:: lessequal
 .. autofunction:: equal 
+.. autofunction:: notequal
 
 There are two additional comparison functions that don't
 correspond to any of the Python comparison operators.


### PR DESCRIPTION
Using `notequal` in `BigFloat.__ne__` fixes a minor discrepancy where `my_bigfloat != some_other_object` ended up calling `some_other_object.__eq__` rather than `some_other_object.__ne__`.  Tests for that will arrive shortly.
