### PR TITLE
Documentation fixes and cleanup.

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -131,7 +131,7 @@ exclude_patterns = []
 #default_role = None
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
-#add_function_parentheses = True
+add_function_parentheses = False
 
 # If true, the current module name will be prepended to all description
 # unit titles (such as .. function::).
@@ -316,7 +316,9 @@ texinfo_documents = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'http://docs.python.org/': None}
+intersphinx_mapping = {
+    'python': ('http://docs.python.org/3/', None)
+}
 
 
 # Workaround for failing PDF build due to a Unicode minus sign.

--- a/docs/source/reference/index.rst
+++ b/docs/source/reference/index.rst
@@ -1,3 +1,5 @@
+.. _api reference:
+
 API Reference
 -------------
 
@@ -76,7 +78,7 @@ zero, and NaNs.
       resulting :class:`BigFloat` has a precision sufficiently large to hold the
       converted value exactly.  If value is a string, then the
       precision argument must be given.  The string is converted using
-      the given precision and the RoundTiesToEven rounding mode.
+      the given precision and the :data:`RoundTiesToEven` rounding mode.
 
    .. method:: fromhex(cls, value, context=None)
 
@@ -132,7 +134,7 @@ deviations from expected behaviour.
   does not affect the result of a comparison.
 
 * Conversions to int and long always round towards zero; conversions
-  to float always use the ``RoundTiesToEven`` rounding mode.
+  to float always use the :data:`ROUND_TIES_TO_EVEN` rounding mode.
   Conversion to bool returns False for a nonzero :class:`BigFloat` and True
   otherwise.  None of these conversions is affected by the current
   context.
@@ -152,16 +154,16 @@ a rounding mode.
 
 .. class:: Context(precision=None, emin=None, emax=None, subnormalize=None, rounding=None)
 
-   Create a new Context object with the given attributes.  Not all
-   attributes need to be specified.  Note that all attributes of the
-   generated Context are read-only.  Attributes that are unset for
-   this Context instance return ``None``.
+   Create a new :class:`Context` object with the given attributes.  Not all
+   attributes need to be specified.  Note that all attributes of the generated
+   :class:`Context` are read-only.  Attributes that are unset for this
+   :class:`Context` instance return ``None``.
 
    .. attribute:: precision
 
       Precision of the floating-point format, given in bits.  This
-      should be an integer in the range [``PRECISION_MIN``,
-      ``PRECISION_MAX``].  ``PRECISION_MIN`` is usually ``2``.
+      should be an integer in the range [:data:`PRECISION_MIN`,
+      :data:`PRECISION_MAX`].
 
    .. attribute:: emax
 
@@ -189,26 +191,25 @@ a rounding mode.
 
    .. attribute:: rounding
 
-      The rounding mode of this Context.  This should be a string.
-      Valid values are 'RoundTiesToEven', 'RoundTowardZero',
-      'RoundTowardPositive' and 'RoundTowardNegative'.  Note that the
-      rounding modes ``RoundTiesToEven``, etc. exported by the
-      :mod:`bigfloat` package are Context instances, not strings, so
-      cannot be used directly here.
+      The rounding mode of this :class:`Context`, for example
+      :data:`ROUND_TIES_TO_EVEN`.  The available rounding modes are described
+      in the :ref:`rounding modes` section.  Note that the values
+      :data:`RoundTiesToEven`, etc. exported by the :mod:`bigfloat` package are
+      :class:`Context` instances, not rounding modes, so cannot be used directly here.
 
 
 :class:`Context` instances can be added.  If ``x`` and ``y`` are
-Context instances then ``x + y`` is the Context whose attributes
+:class:`Context` instances then ``x + y`` is the :class:`Context` whose attributes
 combine those of ``x`` and ``y``.  In the case that both ``x`` and
 ``y`` have a particular attribute set, the value for ``y`` takes
 precedence:
 
-   >>> x = Context(precision=200, rounding='RoundTiesToEven')
+   >>> x = Context(precision=200, rounding=ROUND_TIES_TO_EVEN)
    >>> y = Context(precision=53, subnormalize=True)
    >>> x + y
-   Context(precision=53, subnormalize=True, rounding='RoundTiesToEven')
+   Context(precision=53, subnormalize=True, rounding=ROUND_TIES_TO_EVEN)
    >>> y + x
-   Context(precision=200, subnormalize=True, rounding='RoundTiesToEven')
+   Context(precision=200, subnormalize=True, rounding=ROUND_TIES_TO_EVEN)
 
 :class:`Context` instances can be used in with statements to alter
 the current context.  In effect, ::
@@ -227,7 +228,7 @@ except that nesting of with statements works as you'd expect, and the
 old context is guaranteed to be restored even if an exception occurs
 during execution of the block.
 
-Note that for Context instances ``x`` and ``y``, ::
+Note that for :class:`Context` instances ``x`` and ``y``, ::
 
    with x + y:
        <block>
@@ -249,7 +250,7 @@ instances.
 
 .. data:: EmptyContext
 
-   Equal to Context().  Occasionally useful where a context is
+   Equal to ``Context()``.  Occasionally useful where a context is
    syntactically required for a with statement, but no change to the
    current context is desired.  For example::
 
@@ -278,16 +279,18 @@ instances.
 
 .. data:: RoundTiesToEven
 .. data:: RoundTowardZero
+.. data:: RoundAwayFromZero
 .. data:: RoundTowardPositive
 .. data:: RoundTowardNegative
 
-   Contexts corresponding to the four available rounding modes.
-   ``RoundTiesToEven`` rounds the result of an operation or function
-   to the nearest representable :class:`BigFloat`, with ties rounded to the
-   :class:`BigFloat` whose least significant bit is zero.  ``RoundTowardZero``
-   rounds results towards zero.  ``RoundTowardPositive`` rounds
-   results towards positive infinity, and ``RoundTowardsNegative``
-   rounds results towards negative infinity.
+   :class:`Context` objects corresponding to the five available `rounding modes
+   <rounding modes_>`_.  ``RoundTiesToEven`` rounds the result of an operation
+   or function to the nearest representable :class:`BigFloat`, with ties
+   rounded to the :class:`BigFloat` whose least significant bit is zero.
+   ``RoundTowardZero`` rounds results towards zero.  ``RoundAwayFromZero``
+   rounds results away from zero.  ``RoundTowardPositive`` rounds results
+   towards positive infinity, and ``RoundTowardsNegative`` rounds results
+   towards negative infinity.
 
 Constants
 """""""""
@@ -295,32 +298,32 @@ Constants
 .. data:: PRECISION_MIN
 .. data:: PRECISION_MAX
 
-   Minimum and maximum precision that's valid for Contexts and
+   Minimum and maximum precision that's valid for :class:`Context` and
    :class:`BigFloat` instances.  In the current implementation,
    ``PRECISION_MIN`` is ``2`` and ``PRECISION_MAX`` is ``2**31-1``.
 
 .. data:: EMIN_MIN
 .. data:: EMIN_MAX
 
-   Minimum and maximum allowed values for the Context emin attribute.
+   Minimum and maximum allowed values for the :class:`Context` emin attribute.
    In the current implementation, ``EMIN_MIN == -EMIN_MAX == 1-2**30``.
 
 .. data:: EMAX_MIN
 .. data:: EMAX_MAX
 
-   Minimum and maximum allowed values for the Context emax attribute.
+   Minimum and maximum allowed values for the :class:`Context` emax attribute.
    In the current implementation, ``-EMAX_MIN == EMAX_MAX == 2**30-1``.
 
+.. _current context:
 
 The current context
 """""""""""""""""""
 
-There can be many Context objects in existence at one time, but
-there's only ever one *current context*.  The current context is given
-by a thread-local :class:`Context` instance.  Whenever the :class:`BigFloat`
-constructor is called, or any arithmetic operation or standard
-function computation is performed, the current context is consulted to
-determine:
+There can be many :class:`Context` objects in existence at one time, but
+there's only ever one *current context*.  The current context is given by a
+thread-local :class:`Context` instance.  Whenever the :class:`BigFloat`
+constructor is called, or any arithmetic operation or standard function
+computation is performed, the current context is consulted to determine:
 
 * The format that the result of the operation or function should take
   (as specified by the ``precision``, ``emax``, ``emin`` and
@@ -353,6 +356,41 @@ function that's often useful in calculations:
 
 .. autofunction:: extra_precision
 
+
+.. _rounding modes:
+
+Rounding modes
+^^^^^^^^^^^^^^
+
+.. data:: ROUND_TIES_TO_EVEN
+
+   This is the default rounding mode.  The number to be rounded is mapped to
+   the nearest representable value.  In the case where that number is exactly
+   midway between the two closest representable values, it is mapped to the
+   value with least significant bit set to zero.
+
+.. data:: ROUND_TOWARD_ZERO
+
+   The number to be rounded is mapped to the nearest representable value
+   that's smaller than or equal to the original number in absolute value.
+
+.. data:: ROUND_AWAY_FROM_ZERO
+
+   The number to be rounded is mapped to the nearest representable value
+   that's greater than or equal to the original number in absolute value.
+
+.. data:: ROUND_TOWARD_POSITIVE
+
+   The number to be rounded is mapped to the nearest representable value
+   greater than or equal to the original number. 
+
+.. data:: ROUND_TOWARD_NEGATIVE
+
+   The number to be rounded is mapped to the nearest representable value
+   less than or equal to the original number. 
+
+
+.. _standard functions:
 
 Standard functions
 ^^^^^^^^^^^^^^^^^^

--- a/docs/source/tutorial/index.rst
+++ b/docs/source/tutorial/index.rst
@@ -1,16 +1,17 @@
 Tutorial
 --------
 
-Start by importing the contents of the package (assuming that you've
-already installed it and its prerequisites) with:
+.. currentmodule:: bigfloat
+
+Start by importing the contents of the package with:
 
    >>> from bigfloat import *
 
 You should be a little bit careful here: this import brings a fairly large
 number of functions into the current namespace, four of which shadow existing
-Python builtins, namely ``abs``, ``max``, ``min`` and ``pow``.  In normal usage
-you'll probably only want to import the classes and functions that you actually
-need.
+Python builtins, namely :func:`abs`, :func:`max`, :func:`min` and :func:`pow`.
+In normal usage you'll probably only want to import the classes and functions
+that you actually need.
 
 
 :class:`BigFloat` construction
@@ -49,7 +50,7 @@ argument to the constructor:
 
 The first argument to the :class:`BigFloat` constructor is rounded to
 the correct precision using the *current rounding mode*, which
-defaults to ``RoundTiesToEven``; again, this can be overridden with
+defaults to :data:`RoundTiesToEven`; again, this can be overridden with
 the ``context`` keyword argument:
 
    >>> BigFloat('3.14')
@@ -59,45 +60,45 @@ the ``context`` keyword argument:
    >>> BigFloat('3.14', context=RoundTowardPositive + precision(24))
    BigFloat.exact('3.14000010', precision=24)
 
-More generally, the second argument to the :class:`BigFloat`
-constructor can be any instance of the :class:`Context` class.  The
-various rounding modes are all Context instances, and ``precision`` is
-a function returning a Context:
+More generally, the second argument to the :class:`BigFloat` constructor can be
+any instance of the :class:`Context` class.  The various rounding modes are all
+:class:`Context` instances, and :func:`precision` is a function returning a
+:class:`Context`:
 
    >>> RoundTowardNegative
-   Context(rounding='RoundTowardNegative')
+   Context(rounding=ROUND_TOWARD_NEGATIVE)
    >>> precision(1000)
    Context(precision=1000)
 
-Context instances can be combined by addition, as seen above.
+:class:`Context` instances can be combined by addition, as seen above.
 
    >>> precision(1000) + RoundTowardNegative
-   Context(precision=1000, rounding='RoundTowardNegative')
+   Context(precision=1000, rounding=ROUND_TOWARD_NEGATIVE)
 
 When adding two contexts that both specify values for a particular
 attribute, the value for the right-hand addend takes precedence::
 
-   >>> c = Context(subnormalize=False, rounding='RoundTowardPositive')
+   >>> c = Context(subnormalize=False, rounding=ROUND_TOWARD_POSITIVE)
    >>> double_precision
    Context(precision=53, emax=1024, emin=-1073, subnormalize=True)
    >>> double_precision + c
    Context(precision=53, emax=1024, emin=-1073, subnormalize=False,
-   rounding='RoundTowardPositive')
+   rounding=ROUND_TOWARD_POSITIVE)
    >>> c + double_precision
    Context(precision=53, emax=1024, emin=-1073, subnormalize=True,
-   rounding='RoundTowardPositive')
+   rounding=ROUND_TOWARD_POSITIVE)
 
-The :mod:`bigfloat` package also defines various constant Context instances.
-For example, ``quadruple_precision`` is a Context that corresponds to
-the IEEE 754 binary128 interchange format::
+The :mod:`bigfloat` package also defines various constant :class:`Context`
+instances.  For example, :data:`quadruple_precision` is a :class:`Context`
+object that corresponds to the IEEE 754 binary128 interchange format::
 
    >>> quadruple_precision
    Context(precision=113, emax=16384, emin=-16493, subnormalize=True)
    >>> BigFloat('1.1', quadruple_precision)
    BigFloat.exact('1.10000000000000000000000000000000008', precision=113)
 
-The current settings for precision and rounding mode given by the
-*current context*, accessible via the :func:`getcontext` function:
+The current settings for precision and rounding mode given by the :ref:`current
+context <current context>`, accessible via the :func:`getcontext` function:
 
    >>> getcontext()
    Context(precision=53, emax=1073741823, emin=-1073741823, subnormalize=False,
@@ -107,7 +108,7 @@ There's also a :func:`setcontext` function for changing the current
 context; however, the preferred method for making temporary changes to
 the current context is to use Python's with statement.  More on this below.
 
-Note that (in contrast to Python's standard library decimal module),
+Note that (in contrast to Python's standard library :mod:`decimal` module),
 :class:`Context` instances are immutable.
 
 There's a second method for constructing :class:`BigFloat`
@@ -125,16 +126,15 @@ setting):
    >>> BigFloat.exact(-56.7)
    BigFloat.exact('-56.700000000000003', precision=53)
 
-For strings, :meth:`BigFloat.exact` accepts a second ``precision``
-argument, and always rounds using the ``RoundTiesToEven`` rounding
-mode.
+For strings, :meth:`BigFloat.exact` accepts a second ``precision`` argument,
+and always rounds using the :data:`ROUND_TIES_TO_EVEN` rounding mode.
 
    >>> BigFloat.exact('1.1', precision=80)
    BigFloat.exact('1.1000000000000000000000003', precision=80)
 
-The result of a call to :class:`BigFloat`.exact is independent of the current
+The result of a call to :meth:`BigFloat.exact` is independent of the current
 context; this is why the :func:`repr` of a :class:`BigFloat` is expressed in
-terms of :meth:`BigFloat.exact`.  The :func:`str` of a :class:`BigFloat` looks
+terms of :meth:`BigFloat.exact`.  The :class:`str` of a :class:`BigFloat` looks
 prettier, but doesn't supply enough information to recover that
 :class:`BigFloat` exactly if you don't know the precision:
 
@@ -162,7 +162,7 @@ the exact mathematical result to the nearest :class:`BigFloat`.
 
 For mixed-type operations, the integer or float is converted *exactly*
 to a :class:`BigFloat` before the operation (as though the
-:class:`BigFloat`.exact constructor had been applied to it).  So
+:meth:`BigFloat.exact` constructor had been applied to it).  So
 there's only a single point where precision might be lost: namely,
 when the result of the operation is rounded to the nearest value
 representable as a :class:`BigFloat`.
@@ -193,7 +193,7 @@ corresponds to usual (true) division:
 
 This is useful for a couple of reasons: one reason is that it makes it
 possible to use ``div(x, y)`` in contexts where a :class:`BigFloat` result is
-desired but where one or both of x and y might be an integer or float.
+desired but where one or both of ``x`` and ``y`` might be an integer or float.
 But a more important reason is that these functions, like the :class:`BigFloat`
 constructor, accept an extra ``context`` keyword argument giving a
 context for the operation::
@@ -201,7 +201,7 @@ context for the operation::
    >>> div(355, 113, context=single_precision)
    BigFloat.exact('3.14159298', precision=24)
 
-Similarly, the ``sub`` function corresponds to Python's subtraction
+Similarly, the :func:`sub` function corresponds to Python's subtraction
 operation.  To fully appreciate some of the subtleties of the ways
 that binary arithmetic operations might be performed, note the
 difference in the results of the following:
@@ -234,44 +234,46 @@ The :mod:`bigfloat` package provides a number of standard mathematical
 functions.  These functions follow the same rules as the arithmetic
 operations above:
 
-  - the arguments can be integers, floats or :class:`BigFloat` instances
+- the arguments can be integers, floats or :class:`BigFloat` instances
 
-  - integers and float arguments are converted exactly to :class:`BigFloat`
-    instances before the function is applied
+- integers and float arguments are converted exactly to :class:`BigFloat`
+  instances before the function is applied
 
-  - the result is a :class:`BigFloat` instance, with the precision of
-    the result, and the rounding mode used to obtain the result, taken
-    from the current context.
+- the result is a :class:`BigFloat` instance, with the precision of
+  the result, and the rounding mode used to obtain the result, taken
+  from the current context.
 
-  - attributes of the current context can be overridden by providing
-    an additional ``context`` keyword argument.  Here are some
-    examples:
+- attributes of the current context can be overridden by providing
+  an additional ``context`` keyword argument.
 
-   >>> sqrt(1729, context=RoundTowardZero)
-   BigFloat.exact('41.581245772583578', precision=53)
-   >>> sqrt(1729, context=RoundTowardPositive)
-   BigFloat.exact('41.581245772583586', precision=53)
-   >>> atanh(0.5, context=precision(20))
-   BigFloat.exact('0.54930592', precision=20)
-   >>> const_catalan(precision(1000))
-   BigFloat.exact('0.9159655941772190150546035149323841107741493742816721342664
-   9811962176301977625476947935651292611510624857442261919619957903589880332585
-   9059431594737481158406995332028773319460519038727478164087865909024706484152
-   1630002287276409423882599577415088163974702524820115607076448838078733704899
-   00864775113226027', precision=1000)
-   >>> 4*exp(-const_pi()/2/agm(1, 1e-100))
-   BigFloat.exact('9.9999999999998517e-101', precision=53)
+Here are some examples::
 
-For a full list of the supported functions, see the reference manual.
+    >>> sqrt(1729, context=RoundTowardZero)
+    BigFloat.exact('41.581245772583578', precision=53)
+    >>> sqrt(1729, context=RoundTowardPositive)
+    BigFloat.exact('41.581245772583586', precision=53)
+    >>> atanh(0.5, context=precision(20))
+    BigFloat.exact('0.54930592', precision=20)
+    >>> const_catalan(precision(1000))
+    BigFloat.exact('0.9159655941772190150546035149323841107741493742816721342664
+    9811962176301977625476947935651292611510624857442261919619957903589880332585
+    9059431594737481158406995332028773319460519038727478164087865909024706484152
+    1630002287276409423882599577415088163974702524820115607076448838078733704899
+    00864775113226027', precision=1000)
+    >>> 4*exp(-const_pi()/2/agm(1, 1e-100))
+    BigFloat.exact('9.9999999999998517e-101', precision=53)
+
+For a full list of the supported functions, see the :ref:`standard functions`
+section of the :ref:`api reference`.
 
 Controlling the precision and rounding mode
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 We've seen one way of controlling precision and rounding mode, via the
 ``context`` keyword argument.  There's another way that's often more
-convenient, especially when a single context change is supposed to
-apply to multiple operations: contexts can be used directly in Python
-``with`` statements.
+convenient, especially when a single context change is supposed to apply to
+multiple operations: contexts can be used directly in Python's :ref:`with
+<with>` statement.
 
 For example, here we compute high-precision upper and lower-bounds for
 the thousandth harmonic number:
@@ -323,12 +325,12 @@ A more permanent change to the context can be effected using the
 An important point here is that in any place that a context is used,
 only the attributes specified by that context are changed.  For
 example, the context ``precision(30)`` only has the ``precision``
-attribute, so only that attribute is affected by the ``setcontext``
+attribute, so only that attribute is affected by the :func:`setcontext`
 call; the other attributes are not changed.  Similarly, the
 ``setcontext(RoundTowardZero)`` line above doesn't affect the
 precision.
 
-There's a ``DefaultContext`` constant giving the default context, so
+There's a :data:`DefaultContext` constant giving the default context, so
 you can always restore the original default context as follows:
 
    >>> setcontext(DefaultContext)


### PR DESCRIPTION
- Fix outdated mentions of string-based rounding modes.
- Include information for `ROUND_AWAY_FROM_ZERO` and `RoundAwayFromZero`
- Other markup fixes.
