### PR TITLE
Various cleanups:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ build/
 # Distribution
 MANIFEST
 dist/
+bigfloat.egg-info/

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ install:
   - sudo apt-get install libmpfr-dev
   - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install unittest2; fi
   - pip install Cython
+  - pip install six
 script:
   - python setup.py build_ext --inplace
   - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then unit2 discover -v; else python -m unittest discover -v; fi

--- a/bigfloat/core.py
+++ b/bigfloat/core.py
@@ -23,6 +23,8 @@
 import sys as _sys
 import contextlib as _contextlib
 
+import six
+
 import mpfr
 
 from bigfloat.rounding_mode import (
@@ -53,9 +55,7 @@ _builtin_pow = pow
 
 
 if _sys.version_info < (3,):
-    INTEGER_TYPES = int, long
-    STRING_TYPES = str, unicode
-
+    long_integer_type = long  # noqa
     if _sys.maxsize == 2**31 - 1:
         _PyHASH_MODULUS = 2**31 - 1
     elif _sys.maxsize == 2**63 - 1:
@@ -76,9 +76,7 @@ if _sys.version_info < (3,):
         return 4 * len(hex_n) - _bit_length_correction[hex_n[0]]
 
 else:
-    INTEGER_TYPES = int,
-    STRING_TYPES = str,
-
+    long_integer_type = int
     _PyHASH_MODULUS = _sys.hash_info.modulus
     _PyHASH_INF = _sys.hash_info.inf
     _PyHASH_NAN = _sys.hash_info.nan
@@ -288,9 +286,9 @@ class BigFloat(mpfr.Mpfr_t):
 
         if isinstance(value, float):
             return _set_d(value)
-        elif isinstance(value, STRING_TYPES):
+        elif isinstance(value, six.string_types):
             return set_str2(value.strip(), 10)
-        elif isinstance(value, INTEGER_TYPES):
+        elif isinstance(value, six.integer_types):
             return set_str2('%x' % value, 16)
         elif isinstance(value, BigFloat):
             return pos(value)
@@ -313,7 +311,7 @@ class BigFloat(mpfr.Mpfr_t):
         """
 
         # figure out precision to use
-        if isinstance(value, STRING_TYPES):
+        if isinstance(value, six.string_types):
             if precision is None:
                 raise TypeError("precision must be supplied when "
                                 "converting from a string")
@@ -324,7 +322,7 @@ class BigFloat(mpfr.Mpfr_t):
                                 "from a string")
             if isinstance(value, float):
                 precision = _builtin_max(DBL_PRECISION, PRECISION_MIN)
-            elif isinstance(value, INTEGER_TYPES):
+            elif isinstance(value, six.integer_types):
                 precision = _builtin_max(_bit_length(value), PRECISION_MIN)
             elif isinstance(value, BigFloat):
                 precision = value.precision
@@ -341,7 +339,7 @@ class BigFloat(mpfr.Mpfr_t):
                 raise ValueError("value too large to represent as a BigFloat")
             if test_flag(Underflow):
                 raise ValueError("value too small to represent as a BigFloat")
-            if test_flag(Inexact) and not isinstance(value, STRING_TYPES):
+            if test_flag(Inexact) and not isinstance(value, six.string_types):
                 # since this is supposed to be an exact conversion, the
                 # inexact flag should never be set except when converting
                 # from a string.
@@ -473,7 +471,7 @@ class BigFloat(mpfr.Mpfr_t):
 
         sign = '-' if self._sign() else ''
         e = self._exponent()
-        if isinstance(e, STRING_TYPES):
+        if isinstance(e, six.string_types):
             return sign + e
 
         m = self._significand()
@@ -744,7 +742,7 @@ class BigFloat(mpfr.Mpfr_t):
             return not is_zero(self)
 
         def __long__(self):
-            return long(int(self))
+            return long_integer_type(self.__int__())
     else:
         def __hash__(self):
             if is_nan(self):
@@ -787,7 +785,7 @@ class BigFloat(mpfr.Mpfr_t):
 
         # ints, long and floats mix freely with BigFloats, and are
         # converted exactly.
-        if isinstance(arg, INTEGER_TYPES) or isinstance(arg, float):
+        if isinstance(arg, six.integer_types) or isinstance(arg, float):
             return cls.exact(arg)
         elif isinstance(arg, BigFloat):
             return arg

--- a/bigfloat/test/test_bigfloat.py
+++ b/bigfloat/test/test_bigfloat.py
@@ -15,8 +15,10 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with the bigfloat package.  If not, see <http://www.gnu.org/licenses/>.
 
+import six
 
 # Standard library imports
+from six.moves import builtins
 import doctest
 import fractions
 import operator
@@ -28,9 +30,6 @@ else:
     import unittest
 
 import bigfloat.core
-
-_builtin_abs = abs
-_builtin_pow = pow
 
 from bigfloat import (
     # version number
@@ -96,6 +95,11 @@ from bigfloat.core import _all_flags
 
 all_rounding_modes = [RoundTowardZero, RoundTowardNegative,
                       RoundTowardPositive, RoundTiesToEven, RoundAwayFromZero]
+
+if sys.version_info < (3,):
+    long_integer_type = long  # noqa
+else:
+    long_integer_type = int
 
 
 def diffBigFloat(x, y, match_precisions=True):
@@ -322,7 +326,7 @@ class BigFloatTests(unittest.TestCase):
         self.assertEqual(bf % other, "rmod")
         self.assertEqual(divmod(bf, other), "rdivmod")
         self.assertEqual(bf ** other, "rpow")
-        self.assertEqual(_builtin_pow(bf, other), "rpow")
+        self.assertEqual(builtins.pow(bf, other), "rpow")
         if sys.version_info < (3,):
             self.assertEqual(operator.div(bf, other), "rdiv")
         if sys.version_info >= (3, 5):
@@ -600,7 +604,7 @@ class BigFloatTests(unittest.TestCase):
 
     if sys.version_info < (3,):
         def test_creation_from_unicode(self):
-            test_values = map(unicode,
+            test_values = map(six.text_type,
                               ['123.456',
                                '-1.23',
                                '1e456',
@@ -731,13 +735,14 @@ class BigFloatTests(unittest.TestCase):
 
     if sys.version_info < (3,):
         def test_exact_creation_from_unicode(self):
-            test_values = map(unicode, ['123.456',
-                                        '-1.23',
-                                        '1e456',
-                                        '+nan',
-                                        'inf',
-                                        '-inf',
-                                        '-451.001'])
+            test_values = map(six.text_type,
+                              ['123.456',
+                               '-1.23',
+                               '1e456',
+                               '+nan',
+                               'inf',
+                               '-inf',
+                               '-451.001'])
             test_precisions = [2, 20, 53, 2000]
             for value in test_values:
                 for p in test_precisions:
@@ -913,21 +918,26 @@ class BigFloatTests(unittest.TestCase):
 
     if sys.version_info < (3,):
         def test_long(self):
-            self.assertIsInstance(long(BigFloat(13.7)), long)
-            self.assertEqual(long(BigFloat(13.7)), 13)
-            self.assertIsInstance(long(BigFloat(13.7)), long)
-            self.assertEqual(long(BigFloat(2.3)), 2)
-            self.assertIsInstance(long(BigFloat(1729)), long)
-            self.assertEqual(long(BigFloat(1729)), 1729)
+            self.assertIsInstance(
+                long_integer_type(BigFloat(13.7)), long_integer_type)
+            self.assertEqual(long_integer_type(BigFloat(13.7)), 13)
+            self.assertIsInstance(
+                long_integer_type(BigFloat(13.7)), long_integer_type)
+            self.assertEqual(long_integer_type(BigFloat(2.3)), 2)
+            self.assertIsInstance(
+                long_integer_type(BigFloat(1729)), long_integer_type)
+            self.assertEqual(long_integer_type(BigFloat(1729)), 1729)
 
-            self.assertIsInstance(long(BigFloat('0.0')), long)
-            self.assertEqual(long(BigFloat('0.0')), 0)
-            self.assertIsInstance(long(BigFloat('-0.0')), long)
-            self.assertEqual(long(BigFloat('-0.0')), 0)
+            self.assertIsInstance(
+                long_integer_type(BigFloat('0.0')), long_integer_type)
+            self.assertEqual(long_integer_type(BigFloat('0.0')), 0)
+            self.assertIsInstance(
+                long_integer_type(BigFloat('-0.0')), long_integer_type)
+            self.assertEqual(long_integer_type(BigFloat('-0.0')), 0)
 
-            self.assertRaises(ValueError, long, BigFloat('inf'))
-            self.assertRaises(ValueError, long, BigFloat('-inf'))
-            self.assertRaises(ValueError, long, BigFloat('nan'))
+            self.assertRaises(ValueError, long_integer_type, BigFloat('inf'))
+            self.assertRaises(ValueError, long_integer_type, BigFloat('-inf'))
+            self.assertRaises(ValueError, long_integer_type, BigFloat('nan'))
 
     def test_integer_ratio(self):
 
@@ -1124,7 +1134,7 @@ class BigFloatTests(unittest.TestCase):
                 else:
                     self.assertEqual(x, -negx)
 
-                absx = _builtin_abs(x)
+                absx = builtins.abs(x)
                 self.assertEqual(absx.precision, p)
                 if p < 150:
                     self.assertNotEqual(x, absx)

--- a/setup.py
+++ b/setup.py
@@ -17,9 +17,9 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with the bigfloat package.  If not, see <http://www.gnu.org/licenses/>.
 
-from distutils.core import setup
-from distutils.extension import Extension
 import os
+
+from setuptools import setup, Extension
 
 
 DESCRIPTION = """\
@@ -262,6 +262,7 @@ setup(
     version=version_info['release'],
     description=DESCRIPTION,
     long_description=LONG_DESCRIPTION,
+    install_requires=["six"],
     author='Mark Dickinson',
     author_email='dickinsm@gmail.com',
     url='http://github.com/mdickinson/bigfloat',


### PR DESCRIPTION
- Use setuptools instead of distutils.
- Add dependency on six, and use it for string types and integer
  types.
- Flake8 cleanups.
- Add .egg-info files directory to .gitignore.
