### PR TITLE
Feature: floor division

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,10 @@ New Features
 - Add support for ``round``, ``math.floor``, ``math.ceil``, ``math.trunc`` on
   Python 3.
 
+- Add support for ``divmod`` and the ``//`` operator. (#69)
+
+- New ``floordiv`` and ``mod`` functions.  The new ``mod`` replaces the old
+  ``mod`` function, which has been renamed to ``fmod``. (#69)
 
 Changes
 -------
@@ -23,6 +27,11 @@ Changes
   than 'Infinity' and 'NaN', for consistency with the float type, and
   for consistency with the newly-introduced string formatting.
 
+- The 'mod' function now follows Python sign conventions; the old
+  'mod' function has been renamed to 'fmod'.  The '%' operator
+  now also follows Python sign conventions. (#69)
+
+- MPFR version 3.0.0 or later is required.
 
 Bugfixes
 --------

--- a/bigfloat/__init__.py
+++ b/bigfloat/__init__.py
@@ -69,7 +69,7 @@ __all__ = [
 
     # 5.5 Basic arithmetic functions
     'add', 'sub', 'mul', 'sqr', 'div', 'sqrt', 'rec_sqrt', 'cbrt', 'root',
-    'pow', 'neg', 'abs', 'dim',
+    'pow', 'neg', 'abs', 'dim', 'floordiv',
 
     # 5.6 Comparison functions
     'cmp', 'cmpabs', 'is_nan', 'is_inf', 'is_finite', 'is_zero', 'is_regular',
@@ -139,6 +139,7 @@ from bigfloat.core import (
 
     # 5.5 Basic Arithmetic Functions
     add, sub, mul, sqr, div, sqrt, rec_sqrt, cbrt, root, pow, neg, abs, dim,
+    floordiv,
 
     # 5.6 Comparison Functions
     cmp, cmpabs, is_nan, is_inf, is_finite, is_zero, is_regular, sgn,

--- a/bigfloat/__init__.py
+++ b/bigfloat/__init__.py
@@ -69,7 +69,7 @@ __all__ = [
 
     # 5.5 Basic arithmetic functions
     'add', 'sub', 'mul', 'sqr', 'div', 'sqrt', 'rec_sqrt', 'cbrt', 'root',
-    'pow', 'neg', 'abs', 'dim', 'floordiv',
+    'pow', 'neg', 'abs', 'dim', 'floordiv', 'pmod',
 
     # 5.6 Comparison functions
     'cmp', 'cmpabs', 'is_nan', 'is_inf', 'is_finite', 'is_zero', 'is_regular',
@@ -93,7 +93,7 @@ __all__ = [
 
     # 5.10 Integer and Remainder Related Functions
     'ceil', 'floor', 'round', 'trunc',
-    'frac', 'mod', 'remainder', 'is_integer',
+    'frac', 'fmod', 'remainder', 'is_integer',
 
     # 5.12 Miscellaneous Functions
     'min', 'max',
@@ -139,7 +139,7 @@ from bigfloat.core import (
 
     # 5.5 Basic Arithmetic Functions
     add, sub, mul, sqr, div, sqrt, rec_sqrt, cbrt, root, pow, neg, abs, dim,
-    floordiv,
+    floordiv, pmod,
 
     # 5.6 Comparison Functions
     cmp, cmpabs, is_nan, is_inf, is_finite, is_zero, is_regular, sgn,
@@ -163,7 +163,7 @@ from bigfloat.core import (
 
     # 5.10 Integer and Remainder Related Functions
     ceil, floor, round, trunc,
-    frac, mod, remainder, is_integer,
+    frac, fmod, remainder, is_integer,
 
     # 5.12 Miscellaneous Functions
     min, max,

--- a/bigfloat/__init__.py
+++ b/bigfloat/__init__.py
@@ -69,7 +69,7 @@ __all__ = [
 
     # 5.5 Basic arithmetic functions
     'add', 'sub', 'mul', 'sqr', 'div', 'sqrt', 'rec_sqrt', 'cbrt', 'root',
-    'pow', 'neg', 'abs', 'dim', 'floordiv', 'pmod',
+    'pow', 'neg', 'abs', 'dim', 'floordiv', 'mod',
 
     # 5.6 Comparison functions
     'cmp', 'cmpabs', 'is_nan', 'is_inf', 'is_finite', 'is_zero', 'is_regular',
@@ -139,7 +139,9 @@ from bigfloat.core import (
 
     # 5.5 Basic Arithmetic Functions
     add, sub, mul, sqr, div, sqrt, rec_sqrt, cbrt, root, pow, neg, abs, dim,
-    floordiv, pmod,
+
+    # Additional arithmetic functions (not implemented directly by MPFR)
+    floordiv, mod,
 
     # 5.6 Comparison Functions
     cmp, cmpabs, is_nan, is_inf, is_finite, is_zero, is_regular, sgn,

--- a/bigfloat/core.py
+++ b/bigfloat/core.py
@@ -1130,7 +1130,7 @@ def _quotient_exponent(x, y):
     return extra + mpfr.mpfr_get_exp(x) - mpfr.mpfr_get_exp(y)
 
 
-def _mpfr_pmod(rop, x, y, rnd):
+def _mpfr_mod(rop, x, y, rnd):
     """
     Given two MPRF numbers x and y, compute
     x - floor(x / y) * y, rounded if necessary using the given
@@ -1307,14 +1307,14 @@ def floordiv(x, y, context=None):
     )
 
 
-def pmod(x, y, context=None):
+def mod(x, y, context=None):
     """
     Return the remainder of x divided by y, with sign matching that of y.
 
     """
     return _apply_function_in_current_context(
         BigFloat,
-        _mpfr_pmod,
+        _mpfr_mod,
         (
             BigFloat._implicit_convert(x),
             BigFloat._implicit_convert(y),

--- a/bigfloat/core.py
+++ b/bigfloat/core.py
@@ -51,6 +51,8 @@ from bigfloat.formatting import (
     rounding_mode_from_specifier,
 )
 
+from bigfloat.mpfr_supplemental import mpfr_floordiv, mpfr_mod
+
 
 # Alternative names for some builtins that get overwritten by functions created
 # in this module.
@@ -1109,184 +1111,6 @@ def div(x, y, context=None):
     )
 
 
-def _quotient_exponent(x, y):
-    """
-    Given two positive finite MPFR instances x and y,
-    find the exponent of x / y; that is, the unique
-    integer e such that 2**(e-1) <= x / y < 2**e.
-
-    """
-    assert mpfr.mpfr_regular_p(x)
-    assert mpfr.mpfr_regular_p(y)
-
-    # Make copy of x with the exponent of y.
-    x2 = mpfr.Mpfr_t()
-    mpfr.mpfr_init2(x2, mpfr.mpfr_get_prec(x))
-    mpfr.mpfr_set(x2, x, mpfr.MPFR_RNDN)
-    mpfr.mpfr_set_exp(x2, mpfr.mpfr_get_exp(y))
-
-    # Compare x2 and y, disregarding the sign.
-    extra = mpfr.mpfr_cmpabs(x2, y) >= 0
-    return extra + mpfr.mpfr_get_exp(x) - mpfr.mpfr_get_exp(y)
-
-
-def _mpfr_mod(rop, x, y, rnd):
-    """
-    Given two MPRF numbers x and y, compute
-    x - floor(x / y) * y, rounded if necessary using the given
-    rounding mode.  The result is placed in 'rop'.
-
-    This is the 'remainder' operation, with sign convention
-    compatible with Python's % operator (where x % y has
-    the same sign as y).
-    """
-    # There are various cases:
-    #
-    # 0. If either argument is a NaN, the result is NaN.
-    #
-    # 1. If x is infinite or y is zero, the result is NaN.
-    #
-    # 2. If y is infinite, return 0 with the sign of y if x is zero, x if x has
-    #    the same sign as y, and infinity with the sign of y if it has the
-    #    opposite sign.
-    #
-    # 3. If none of the above cases apply then both x and y are finite,
-    #    and y is nonzero.  If x and y have the same sign, simply
-    #    return the result of fmod(x, y).
-    #
-    # 4. Now both x and y are finite, y is nonzero, and x and y have
-    #    differing signs.  Compute r = fmod(x, y) with sufficient precision
-    #    to get an exact result.  If r == 0, return 0 with the sign of y
-    #    (which will be the opposite of the sign of x).  If r != 0,
-    #    return r + y, rounded appropriately.
-
-    if not mpfr.mpfr_number_p(x) or mpfr.mpfr_nan_p(y) or mpfr.mpfr_zero_p(y):
-        return mpfr.mpfr_fmod(rop, x, y, rnd)
-    elif mpfr.mpfr_inf_p(y):
-        x_negative = mpfr.mpfr_signbit(x)
-        y_negative = mpfr.mpfr_signbit(y)
-        if mpfr.mpfr_zero_p(x):
-            mpfr.mpfr_set_zero(rop, -y_negative)
-            return 0
-        elif x_negative == y_negative:
-            return mpfr.mpfr_set(rop, x, rnd)
-        else:
-            mpfr.mpfr_set_inf(rop, -y_negative)
-            return 0
-
-    x_negative = mpfr.mpfr_signbit(x)
-    y_negative = mpfr.mpfr_signbit(y)
-    if x_negative == y_negative:
-        return mpfr.mpfr_fmod(rop, x, y, rnd)
-    else:
-        p = max(mpfr.mpfr_get_prec(x), mpfr.mpfr_get_prec(y))
-        z = mpfr.Mpfr_t.__new__(BigFloat)
-        mpfr.mpfr_init2(z, p)
-        # Doesn't matter what rounding mode we use here; the result
-        # should be exact.
-        ternary = mpfr.mpfr_fmod(z, x, y, rnd)
-        assert ternary == 0
-        if mpfr.mpfr_zero_p(z):
-            mpfr.mpfr_set_zero(rop, -y_negative)
-            return 0
-        else:
-            return mpfr.mpfr_add(rop, y, z, rnd)
-
-
-def _mpfr_floordiv(rop, x, y, rnd):
-    """
-    Given two MPFR numbers x and y, compute floor(x / y),
-    rounded if necessary using the given rounding mode.
-    The result is placed in 'rop'.
-    """
-    # Algorithm notes
-    # ---------------
-    # A simple and obvious approach is to compute floor(x / y) exactly, and
-    # then round to the nearest representable value using the given rounding
-    # mode.  This requires computing x / y to a precision sufficient to ensure
-    # that floor(x / y) is exactly representable.  If abs(x / y) < 2**r, then
-    # abs(floor(x / y)) <= 2**r, and so r bits of precision is enough.
-    # However, for large quotients this is impractical, and we need some other
-    # method.  For x / y sufficiently large, it's possible to show that x / y
-    # and floor(x / y) are indistinguishable, in the sense that both quantities
-    # round to the same value.  More precisely, we have the following theorem:
-    #
-    # Theorem.  Suppose that x and y are nonzero finite binary floats
-    # representable with p and q bits of precision, respectively.  Let R be any
-    # of the IEEE 754 standard rounding modes, and choose a target precision r.
-    # Write rnd for the rounding operation from Q to precision-r binary floats
-    # with rounding mode R.  Write bin(x) for the binade of a nonzero float x.
-    #
-    # If R is a round-to-nearest rounding mode, and either
-    #
-    # (1) p <= q + r and |x / y| >= 2^(q + r), or
-    # (2) p > q + r and bin(x) - bin(y) >= p
-    #
-    # then
-    #
-    #    rnd(floor(x / y)) == rnd(x / y)
-    #
-    # Conversely, if R is a directed rounding mode, and either
-    #
-    # (1) p < q + r and |x / y| >= 2^(q + r - 1), or
-    # (2) p >= q + r and bin(x) - bin(y) >= p
-    #
-    # then again
-    #
-    #    rnd(floor(x / y)) == rnd(x / y).
-    #
-    # Proof.  See separate notes and Coq proof in the float-proofs
-    # repository.
-    #
-    # Rather than distinguish between the various cases (R directed
-    # or not, p large versus p small) above, we use a weaker but
-    # simpler amalgamation of the above result:
-    #
-    # Corollary 1. With x, y, p, q, R, r and rnd as above, if
-    #
-    #     |x / y| >= 2^max(q + r, p)
-    #
-    # then
-    #
-    #     rnd(floor(x / y)) == rnd(x / y).
-    #
-    # Proof. Note that |x / y| >= 2^p implies bin(x) - bin(y) >= p,
-    # so it's enough that |x / y| >= 2^max(p, q + r) in the case of
-    # a round-to-nearest mode, and that |x / y| >= 2^max(p, q + r - 1)
-    # in the case of a directed rounding mode.
-
-    # In special cases, it's safe to defer to mpfr_div: the result in
-    # these cases is always 0, infinity, or nan.
-    if not mpfr.mpfr_regular_p(x) or not mpfr.mpfr_regular_p(y):
-        return mpfr.mpfr_div(rop, x, y, rnd)
-
-    e = _quotient_exponent(x, y)
-
-    p = mpfr.mpfr_get_prec(x)
-    q = mpfr.mpfr_get_prec(y)
-    r = mpfr.mpfr_get_prec(rop)
-
-    # If e - 1 >= max(p, q+r) then |x / y| >= 2^(e-1) >= 2^max(p, q+r),
-    # so by the above theorem, round(floordiv(x, y)) == round(div(x, y)).
-    if e - 1 >= max(p, q + r):
-        return mpfr.mpfr_div(rop, x, y, rnd)
-
-    # Slow version: compute to sufficient bits to get integer precision.  Given
-    # that 2**(e-1) <= x / y < 2**e, need >= e bits of precision.
-    z_prec = max(e, 2)
-    z = mpfr.Mpfr_t()
-    mpfr.mpfr_init2(z, z_prec)
-
-    # Compute the floor exactly.
-    with _saved_flags():
-        mpfr.mpfr_div(z, x, y, mpfr.MPFR_RNDD)
-        err = mpfr.mpfr_floor(z, z)
-        assert err in (0, -2)
-
-    # ... and round to the given rounding mode.
-    return mpfr.mpfr_set(rop, z, rnd)
-
-
 def floordiv(x, y, context=None):
     """
     Return the floor of ``x`` divided by ``y``.
@@ -1298,7 +1122,7 @@ def floordiv(x, y, context=None):
     """
     return _apply_function_in_current_context(
         BigFloat,
-        _mpfr_floordiv,
+        mpfr_floordiv,
         (
             BigFloat._implicit_convert(x),
             BigFloat._implicit_convert(y),
@@ -1314,7 +1138,7 @@ def mod(x, y, context=None):
     """
     return _apply_function_in_current_context(
         BigFloat,
-        _mpfr_mod,
+        mpfr_mod,
         (
             BigFloat._implicit_convert(x),
             BigFloat._implicit_convert(y),
@@ -1323,7 +1147,13 @@ def mod(x, y, context=None):
     )
 
 
-def _divmod(x, y, context=None):
+def divmod(x, y, context=None):
+    """
+    Return the pair (floordiv(x, y, context), mod(x, y, context).
+
+    Semantics for negative inputs match those of Python's divmod function.
+
+    """
     return floordiv(x, y, context=context), mod(x, y, context=context)
 
 
@@ -2748,7 +2578,7 @@ if _sys.version_info < (3,):
     BigFloat.__div__ = _binop(div)
 BigFloat.__pow__ = _binop(pow)
 BigFloat.__mod__ = _binop(mod)
-BigFloat.__divmod__ = _binop(_divmod)
+BigFloat.__divmod__ = _binop(divmod)
 
 # and their reverse operations
 BigFloat.__radd__ = _rbinop(add)
@@ -2760,7 +2590,7 @@ if _sys.version_info < (3,):
     BigFloat.__rdiv__ = _rbinop(div)
 BigFloat.__rpow__ = _rbinop(pow)
 BigFloat.__rmod__ = _rbinop(mod)
-BigFloat.__rdivmod__ = _rbinop(_divmod)
+BigFloat.__rdivmod__ = _rbinop(divmod)
 
 # comparisons
 BigFloat.__eq__ = _binop(equal)

--- a/bigfloat/core.py
+++ b/bigfloat/core.py
@@ -1283,7 +1283,11 @@ def _mpfr_floordiv(rop, x, y, rnd):
 
 def floordiv(x, y, context=None):
     """
-    Return floor(x / y).
+    Return the floor of ``x`` divided by ``y``.
+
+    The result is a ``BigFloat`` instance, rounded to the
+    context if necessary.  Special cases match those of the
+    ``div`` function.
 
     """
     return _apply_function_in_current_context(
@@ -2713,6 +2717,7 @@ BigFloat.__add__ = _binop(add)
 BigFloat.__sub__ = _binop(sub)
 BigFloat.__mul__ = _binop(mul)
 BigFloat.__truediv__ = _binop(div)
+BigFloat.__floordiv__ = _binop(floordiv)
 if _sys.version_info < (3,):
     BigFloat.__div__ = _binop(div)
 BigFloat.__pow__ = _binop(pow)
@@ -2722,6 +2727,7 @@ BigFloat.__radd__ = _rbinop(add)
 BigFloat.__rsub__ = _rbinop(sub)
 BigFloat.__rmul__ = _rbinop(mul)
 BigFloat.__rtruediv__ = _rbinop(div)
+BigFloat.__rfloordiv__ = _rbinop(floordiv)
 if _sys.version_info < (3,):
     BigFloat.__rdiv__ = _rbinop(div)
 BigFloat.__rpow__ = _rbinop(pow)

--- a/bigfloat/core.py
+++ b/bigfloat/core.py
@@ -1149,7 +1149,7 @@ def mod(x, y, context=None):
 
 def divmod(x, y, context=None):
     """
-    Return the pair (floordiv(x, y, context), mod(x, y, context).
+    Return the pair (floordiv(x, y, context), mod(x, y, context)).
 
     Semantics for negative inputs match those of Python's divmod function.
 

--- a/bigfloat/core.py
+++ b/bigfloat/core.py
@@ -1254,6 +1254,55 @@ def _mpfr_floordiv(rop, x, y, rnd):
     #
     # Proof.
 
+    # Theorem.  Suppose that x and y are nonzero finite binary floats
+    # representable with p and q bits of precision, respectively.  Choose a
+    # rounding mode R and a target precision r, and write rnd for the
+    # corresponding rounding operation from Q to precision-r binary floats.
+    #
+    # If R is a round-to-nearest rounding mode, and either
+    #
+    # (1) p <= q + r and |x / y| >= 2^(q + r), or
+    # (2) p > q + r and bin(x) - bin(y) >= p
+    #
+    # then
+    #
+    #    rnd(floor(x / y)) == rnd(x / y)
+    #
+    # If R is a directed rounding mode, and either
+    # (1) p < q + r and |x / y| >= 2^(q + r - 1), or
+    # (2) p >= q + r and bin(x) - bin(y) >= p
+    #
+    # then again
+    #
+    #    rnd(floor(x / y)) == rnd(x / y).
+    #
+    # Here's a weaker but simpler result that follows from the above.
+    #
+    # Corollary 1. With x, y, p, q, R, r and rnd as above, if
+    #
+    #     |x / y| >= 2^max(q + r, p)
+    #
+    # then
+    #
+    #     rnd(floor(x / y)) == rnd(x / y).
+    #
+    # Proof. Note that |x / y| >= 2^p implies bin(x) - bin(y) >= p,
+    # so it's enough that |x / y| >= 2^max(p, q + r) in the case of
+    # a round-to-nearest mode, and that |x / y| >= 2^max(p, q + r - 1)
+    # in the case of a directed rounding mode.
+    #
+    # Or an alternative simplification.
+    #
+    # Corollary 2. With x, y, p, q, R, r and rnd as above, if
+    #
+    #     bin(x) - bin(y) >= max(p, q + r + 1)
+    #
+    # then
+    #
+    #     rnd(floor(x / y)) == rnd(x / y)
+    #
+    # Proof. If bin(x) - bin(y) >= q + r + 1 then |x / y| > 2^(q + r).
+
     # In special cases, it's safe to defer to mpfr_div: the result in
     # these cases is always 0, infinity, or nan.
     if not mpfr.mpfr_regular_p(x) or not mpfr.mpfr_regular_p(y):

--- a/bigfloat/core.py
+++ b/bigfloat/core.py
@@ -2743,7 +2743,7 @@ BigFloat.__floordiv__ = _binop(floordiv)
 if _sys.version_info < (3,):
     BigFloat.__div__ = _binop(div)
 BigFloat.__pow__ = _binop(pow)
-BigFloat.__mod__ = _binop(fmod)
+BigFloat.__mod__ = _binop(mod)
 
 # and their reverse operations
 BigFloat.__radd__ = _rbinop(add)
@@ -2754,7 +2754,7 @@ BigFloat.__rfloordiv__ = _rbinop(floordiv)
 if _sys.version_info < (3,):
     BigFloat.__rdiv__ = _rbinop(div)
 BigFloat.__rpow__ = _rbinop(pow)
-BigFloat.__rmod__ = _rbinop(fmod)
+BigFloat.__rmod__ = _rbinop(mod)
 
 # comparisons
 BigFloat.__eq__ = _binop(equal)

--- a/bigfloat/core.py
+++ b/bigfloat/core.py
@@ -1323,6 +1323,10 @@ def mod(x, y, context=None):
     )
 
 
+def _divmod(x, y, context=None):
+    return floordiv(x, y, context=context), mod(x, y, context=context)
+
+
 def sqrt(x, context=None):
     """
     Return the square root of ``x``.
@@ -2744,6 +2748,7 @@ if _sys.version_info < (3,):
     BigFloat.__div__ = _binop(div)
 BigFloat.__pow__ = _binop(pow)
 BigFloat.__mod__ = _binop(mod)
+BigFloat.__divmod__ = _binop(_divmod)
 
 # and their reverse operations
 BigFloat.__radd__ = _rbinop(add)
@@ -2755,6 +2760,7 @@ if _sys.version_info < (3,):
     BigFloat.__rdiv__ = _rbinop(div)
 BigFloat.__rpow__ = _rbinop(pow)
 BigFloat.__rmod__ = _rbinop(mod)
+BigFloat.__rdivmod__ = _rbinop(_divmod)
 
 # comparisons
 BigFloat.__eq__ = _binop(equal)

--- a/bigfloat/mpfr_supplemental.py
+++ b/bigfloat/mpfr_supplemental.py
@@ -1,0 +1,206 @@
+# -*- coding: UTF-8
+
+# Copyright 2009--2014 Mark Dickinson.
+#
+# This file is part of the bigfloat package.
+#
+# The bigfloat package is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+#
+# The bigfloat package is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with the bigfloat package.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Supplementary functions with a similar API to those in the mpfr module.
+"""
+import mpfr
+
+
+def _quotient_exponent(x, y):
+    """
+    Given two positive finite MPFR instances x and y,
+    find the exponent of x / y; that is, the unique
+    integer e such that 2**(e-1) <= x / y < 2**e.
+
+    """
+    assert mpfr.mpfr_regular_p(x)
+    assert mpfr.mpfr_regular_p(y)
+
+    # Make copy of x with the exponent of y.
+    x2 = mpfr.Mpfr_t()
+    mpfr.mpfr_init2(x2, mpfr.mpfr_get_prec(x))
+    mpfr.mpfr_set(x2, x, mpfr.MPFR_RNDN)
+    mpfr.mpfr_set_exp(x2, mpfr.mpfr_get_exp(y))
+
+    # Compare x2 and y, disregarding the sign.
+    extra = mpfr.mpfr_cmpabs(x2, y) >= 0
+    return extra + mpfr.mpfr_get_exp(x) - mpfr.mpfr_get_exp(y)
+
+
+def mpfr_floordiv(rop, x, y, rnd):
+    """
+    Given two MPFR numbers x and y, compute floor(x / y),
+    rounded if necessary using the given rounding mode.
+    The result is placed in 'rop'.
+    """
+    # Algorithm notes
+    # ---------------
+    # A simple and obvious approach is to compute floor(x / y) exactly, and
+    # then round to the nearest representable value using the given rounding
+    # mode.  This requires computing x / y to a precision sufficient to ensure
+    # that floor(x / y) is exactly representable.  If abs(x / y) < 2**r, then
+    # abs(floor(x / y)) <= 2**r, and so r bits of precision is enough.
+    # However, for large quotients this is impractical, and we need some other
+    # method.  For x / y sufficiently large, it's possible to show that x / y
+    # and floor(x / y) are indistinguishable, in the sense that both quantities
+    # round to the same value.  More precisely, we have the following theorem:
+    #
+    # Theorem.  Suppose that x and y are nonzero finite binary floats
+    # representable with p and q bits of precision, respectively.  Let R be any
+    # of the IEEE 754 standard rounding modes, and choose a target precision r.
+    # Write rnd for the rounding operation from Q to precision-r binary floats
+    # with rounding mode R.  Write bin(x) for the binade of a nonzero float x.
+    #
+    # If R is a round-to-nearest rounding mode, and either
+    #
+    # (1) p <= q + r and |x / y| >= 2^(q + r), or
+    # (2) p > q + r and bin(x) - bin(y) >= p
+    #
+    # then
+    #
+    #    rnd(floor(x / y)) == rnd(x / y)
+    #
+    # Conversely, if R is a directed rounding mode, and either
+    #
+    # (1) p < q + r and |x / y| >= 2^(q + r - 1), or
+    # (2) p >= q + r and bin(x) - bin(y) >= p
+    #
+    # then again
+    #
+    #    rnd(floor(x / y)) == rnd(x / y).
+    #
+    # Proof.  See separate notes and Coq proof in the float-proofs
+    # repository.
+    #
+    # Rather than distinguish between the various cases (R directed
+    # or not, p large versus p small) above, we use a weaker but
+    # simpler amalgamation of the above result:
+    #
+    # Corollary 1. With x, y, p, q, R, r and rnd as above, if
+    #
+    #     |x / y| >= 2^max(q + r, p)
+    #
+    # then
+    #
+    #     rnd(floor(x / y)) == rnd(x / y).
+    #
+    # Proof. Note that |x / y| >= 2^p implies bin(x) - bin(y) >= p,
+    # so it's enough that |x / y| >= 2^max(p, q + r) in the case of
+    # a round-to-nearest mode, and that |x / y| >= 2^max(p, q + r - 1)
+    # in the case of a directed rounding mode.
+
+    # In special cases, it's safe to defer to mpfr_div: the result in
+    # these cases is always 0, infinity, or nan.
+    if not mpfr.mpfr_regular_p(x) or not mpfr.mpfr_regular_p(y):
+        return mpfr.mpfr_div(rop, x, y, rnd)
+
+    e = _quotient_exponent(x, y)
+
+    p = mpfr.mpfr_get_prec(x)
+    q = mpfr.mpfr_get_prec(y)
+    r = mpfr.mpfr_get_prec(rop)
+
+    # If e - 1 >= max(p, q+r) then |x / y| >= 2^(e-1) >= 2^max(p, q+r),
+    # so by the above theorem, round(floordiv(x, y)) == round(div(x, y)).
+    if e - 1 >= max(p, q + r):
+        return mpfr.mpfr_div(rop, x, y, rnd)
+
+    # Slow version: compute to sufficient bits to get integer precision.  Given
+    # that 2**(e-1) <= x / y < 2**e, need >= e bits of precision.
+    z_prec = max(e, 2)
+    z = mpfr.Mpfr_t()
+    mpfr.mpfr_init2(z, z_prec)
+
+    # Compute the floor exactly. The division may set the
+    # inexact flag, so we save its state first.
+    old_inexact = mpfr.mpfr_inexflag_p()
+    mpfr.mpfr_div(z, x, y, mpfr.MPFR_RNDD)
+    if not old_inexact:
+        mpfr.mpfr_clear_inexflag()
+
+    # Floor result should be exactly representable, so any rounding mode will
+    # do.
+    ternary = mpfr.mpfr_rint_floor(z, z, rnd)
+    assert ternary == 0
+
+    # ... and round to the given rounding mode.
+    return mpfr.mpfr_set(rop, z, rnd)
+
+
+def mpfr_mod(rop, x, y, rnd):
+    """
+    Given two MPRF numbers x and y, compute
+    x - floor(x / y) * y, rounded if necessary using the given
+    rounding mode.  The result is placed in 'rop'.
+
+    This is the 'remainder' operation, with sign convention
+    compatible with Python's % operator (where x % y has
+    the same sign as y).
+    """
+    # There are various cases:
+    #
+    # 0. If either argument is a NaN, the result is NaN.
+    #
+    # 1. If x is infinite or y is zero, the result is NaN.
+    #
+    # 2. If y is infinite, return 0 with the sign of y if x is zero, x if x has
+    #    the same sign as y, and infinity with the sign of y if it has the
+    #    opposite sign.
+    #
+    # 3. If none of the above cases apply then both x and y are finite,
+    #    and y is nonzero.  If x and y have the same sign, simply
+    #    return the result of fmod(x, y).
+    #
+    # 4. Now both x and y are finite, y is nonzero, and x and y have
+    #    differing signs.  Compute r = fmod(x, y) with sufficient precision
+    #    to get an exact result.  If r == 0, return 0 with the sign of y
+    #    (which will be the opposite of the sign of x).  If r != 0,
+    #    return r + y, rounded appropriately.
+
+    if not mpfr.mpfr_number_p(x) or mpfr.mpfr_nan_p(y) or mpfr.mpfr_zero_p(y):
+        return mpfr.mpfr_fmod(rop, x, y, rnd)
+    elif mpfr.mpfr_inf_p(y):
+        x_negative = mpfr.mpfr_signbit(x)
+        y_negative = mpfr.mpfr_signbit(y)
+        if mpfr.mpfr_zero_p(x):
+            mpfr.mpfr_set_zero(rop, -y_negative)
+            return 0
+        elif x_negative == y_negative:
+            return mpfr.mpfr_set(rop, x, rnd)
+        else:
+            mpfr.mpfr_set_inf(rop, -y_negative)
+            return 0
+
+    x_negative = mpfr.mpfr_signbit(x)
+    y_negative = mpfr.mpfr_signbit(y)
+    if x_negative == y_negative:
+        return mpfr.mpfr_fmod(rop, x, y, rnd)
+    else:
+        p = max(mpfr.mpfr_get_prec(x), mpfr.mpfr_get_prec(y))
+        z = mpfr.Mpfr_t()
+        mpfr.mpfr_init2(z, p)
+        # Doesn't matter what rounding mode we use here; the result
+        # should be exact.
+        ternary = mpfr.mpfr_fmod(z, x, y, rnd)
+        assert ternary == 0
+        if mpfr.mpfr_zero_p(z):
+            mpfr.mpfr_set_zero(rop, -y_negative)
+            return 0
+        else:
+            return mpfr.mpfr_add(rop, y, z, rnd)

--- a/bigfloat/test/test_bigfloat.py
+++ b/bigfloat/test/test_bigfloat.py
@@ -294,7 +294,7 @@ class BigFloatTests(unittest.TestCase):
         import struct
         with double_precision:
 
-            for _ in range(100000):
+            for _ in range(10000):
                 x = struct.unpack(
                     '<d', struct.pack('<Q', random.randrange(2**64)))[0]
                 y = struct.unpack(
@@ -2140,13 +2140,13 @@ floordiv inf -0x0p0 -> -inf
 floordiv -inf -0x0p0 -> inf
 
 # NaNs
-floordiv nan 0x0p0 -> nan
-floordiv nan 0x1p0 -> nan
-floordiv nan inf -> nan
-floordiv nan nan -> nan
-floordiv inf nan -> nan
-floordiv 0x1p0 nan -> nan
-floordiv 0x0p0 nan -> nan
+floordiv nan 0x0p0 -> nan NanFlag
+floordiv nan 0x1p0 -> nan NanFlag
+floordiv nan inf -> nan NanFlag
+floordiv nan nan -> nan NanFlag
+floordiv inf nan -> nan NanFlag
+floordiv 0x1p0 nan -> nan NanFlag
+floordiv 0x0p0 nan -> nan NanFlag
 
 # A few random cases.
 floordiv 0x1.b2a98bbcc49b4p+98 0x1.3d74b2d390501p+48 -> 0x1.5e843fc46ffa8p+50

--- a/bigfloat/test/test_bigfloat.py
+++ b/bigfloat/test/test_bigfloat.py
@@ -333,7 +333,7 @@ class BigFloatTests(unittest.TestCase):
 
                 self.assertEqual(
                     actual_result, expected_result,
-                    msg="failure for x = {0!r}, y = {0!r}".format(x, y)
+                    msg="failure for x = {0!r}, y = {1!r}".format(x, y)
                 )
 
     def test_binary_operations(self):

--- a/bigfloat/test/test_bigfloat.py
+++ b/bigfloat/test/test_bigfloat.py
@@ -299,6 +299,7 @@ class BigFloatTests(unittest.TestCase):
             ('-0x1.b71ef34af0215p-459', '-0x1.d7c7b08970e2dp-514'),
             ('-0x1.55b19f5f1eaf4p+888', '-0x1.eab0f46fc89fcp+834'),
             ('0x1.c655a7928d80ap-148', '0x1.ed6b2d073dbaap-202'),
+            ('0x1.80574cc232b58p+407', '0x1.8017ad6a5cd65p+247'),
         ]
 
         with double_precision:
@@ -327,7 +328,9 @@ class BigFloatTests(unittest.TestCase):
                 try:
                     x_frac = fractions.Fraction(*x.as_integer_ratio())
                     y_frac = fractions.Fraction(*y.as_integer_ratio())
-                    expected_result = float(x_frac // y_frac)
+                    # Would like to simply use float(x_frac // y_frac), but the
+                    # float-to-int conversion is not correctly rounded on Python 2.6.
+                    expected_result = BigFloat(x_frac // y_frac)
                 except OverflowError:
                     expected_result = float('inf') if x_frac / y_frac > 0 else float('-inf')
 

--- a/bigfloat/test/test_bigfloat.py
+++ b/bigfloat/test/test_bigfloat.py
@@ -2199,11 +2199,50 @@ floordiv inf nan -> nan NanFlag
 floordiv 0x1p0 nan -> nan NanFlag
 floordiv 0x0p0 nan -> nan NanFlag
 
-# A few random cases.
+# A few randomly-generated cases.
 floordiv 0x1.b2a98bbcc49b4p+98 0x1.3d74b2d390501p+48 -> 0x1.5e843fc46ffa8p+50
 floordiv -0x1.b2a98bbcc49b4p+98 -0x1.3d74b2d390501p+48 -> 0x1.5e843fc46ffa8p+50
 floordiv -0x1.b2a98bbcc49b4p+98 0x1.3d74b2d390501p+48 -> -0x1.5e843fc46ffacp+50
 floordiv 0x1.b2a98bbcc49b4p+98 -0x1.3d74b2d390501p+48 -> -0x1.5e843fc46ffacp+50
+
+# Randomly-generated near-halfway cases.
+floordiv 0x1.7455b4855c470p+158 0x1.9f63221b65037p+52 -> 0x1.caef27bbd32c3p+105 Inexact
+floordiv -0x1.7455b4855c470p+158 0x1.9f63221b65037p+52 -> -0x1.caef27bbd32c4p+105 Inexact
+floordiv 0x1.3e80b2f3da4e3p+158 0x1.55d84f1af57e3p+52 -> 0x1.dd0a000b852e5p+105 Inexact
+floordiv -0x1.3e80b2f3da4e3p+158 0x1.55d84f1af57e3p+52 -> -0x1.dd0a000b852e6p+105 Inexact
+floordiv 0x1.1ef2d934ebab9p+158 0x1.b1f7b86b3147fp+52 -> 0x1.528b96ac455bfp+105 Inexact
+floordiv -0x1.1ef2d934ebab9p+158 0x1.b1f7b86b3147fp+52 -> -0x1.528b96ac455c0p+105 Inexact
+floordiv 0x1.d9e46ba382852p+158 0x1.e12e2c5c55f27p+52 -> 0x1.f83ebede8104bp+105 Inexact
+floordiv -0x1.d9e46ba382852p+158 0x1.e12e2c5c55f27p+52 -> -0x1.f83ebede8104cp+105 Inexact
+floordiv 0x1.0a29a5b5b8f7dp+158 0x1.2c53d755c382dp+52 -> 0x1.c5c170a956bd2p+105 Inexact
+floordiv -0x1.0a29a5b5b8f7dp+158 0x1.2c53d755c382dp+52 -> -0x1.c5c170a956bd2p+105 Inexact
+floordiv 0x1.236ba96f8838bp+158 0x1.e2e23e8730f95p+52 -> 0x1.34fe01ad9e1dep+105 Inexact
+floordiv -0x1.236ba96f8838bp+158 0x1.e2e23e8730f95p+52 -> -0x1.34fe01ad9e1dep+105 Inexact
+floordiv 0x1.1ff3215dc95f4p+158 0x1.ec809f7a6c20bp+52 -> 0x1.2b596bfcd1cd1p+105 Inexact
+floordiv -0x1.1ff3215dc95f4p+158 0x1.ec809f7a6c20bp+52 -> -0x1.2b596bfcd1cd2p+105 Inexact
+floordiv 0x1.b55d8ec0da9fep+158 0x1.f6d8adea89b9fp+52 -> 0x1.bd53bacf4e02fp+105 Inexact
+floordiv -0x1.b55d8ec0da9fep+158 0x1.f6d8adea89b9fp+52 -> -0x1.bd53bacf4e030p+105 Inexact
+floordiv 0x1.2852761e5852bp+158 0x1.7ddb08bf86a6fp+52 -> 0x1.8d509db211a47p+105 Inexact
+floordiv -0x1.2852761e5852bp+158 0x1.7ddb08bf86a6fp+52 -> -0x1.8d509db211a48p+105 Inexact
+floordiv 0x1.1c97fd65f4e7cp+158 0x1.a6ba81f4da293p+52 -> 0x1.58b1a7e0e65cdp+105 Inexact
+floordiv -0x1.1c97fd65f4e7cp+158 0x1.a6ba81f4da293p+52 -> -0x1.58b1a7e0e65cep+105 Inexact
+
+floordiv 0x1.8ae6742f94fcap+158 0x1.af61efd069439p+52 -> 0x1.d4b323e4872fcp+105 Inexact
+floordiv -0x1.8ae6742f94fcap+158 0x1.af61efd069439p+52 -> -0x1.d4b323e4872fcp+105 Inexact
+floordiv 0x1.50371bfb1ded8p+158 0x1.64df147fa2c0bp+52 -> 0x1.e25d6618d002ep+105 Inexact
+floordiv -0x1.50371bfb1ded8p+158 0x1.64df147fa2c0bp+52 -> -0x1.e25d6618d002fp+105 Inexact
+floordiv 0x1.29ad82f921e61p+158 0x1.ee88b9d5af47fp+52 -> 0x1.3430ee7ff9a40p+105 Inexact
+floordiv -0x1.29ad82f921e61p+158 0x1.ee88b9d5af47fp+52 -> -0x1.3430ee7ff9a41p+105 Inexact
+floordiv 0x1.341e592b2ef12p+158 0x1.c5715b0058be3p+52 -> 0x1.5be8a10c7f71ap+105 Inexact
+floordiv -0x1.341e592b2ef12p+158 0x1.c5715b0058be3p+52 -> -0x1.5be8a10c7f71bp+105 Inexact
+floordiv 0x1.281ad0d0b6e5ap+158 0x1.84ad50291a943p+52 -> 0x1.860e39fb7ea4ap+105 Inexact
+floordiv -0x1.281ad0d0b6e5ap+158 0x1.84ad50291a943p+52 -> -0x1.860e39fb7ea4bp+105 Inexact
+floordiv 0x1.1016dc07e1acep+158 0x1.70c44c2b976c1p+52 -> 0x1.79c5994d7f360p+105 Inexact
+floordiv -0x1.1016dc07e1acep+158 0x1.70c44c2b976c1p+52 -> -0x1.79c5994d7f360p+105 Inexact
+floordiv 0x1.c348cf5e24425p+158 0x1.d34d5e92de493p+52 -> 0x1.ee73382469332p+105 Inexact
+floordiv -0x1.c348cf5e24425p+158 0x1.d34d5e92de493p+52 -> -0x1.ee73382469333p+105 Inexact
+floordiv 0x1.bcfea94be48e6p+158 0x1.dde69c1267a85p+52 -> 0x1.dcbefc6ebc8dap+105 Inexact
+floordiv -0x1.bcfea94be48e6p+158 0x1.dde69c1267a85p+52 -> -0x1.dcbefc6ebc8dap+105 Inexact
 
 # Some cases where Python's // on floats gets the wrong result.
 floordiv 0x1.0e31636b07d9dp-898 0x1.c68968514f16bp-954 -> 0x1.3059e434dd2bep+55 Inexact
@@ -2223,6 +2262,20 @@ floordiv -0x1.ff2e8e6fb6a62p+157 0x1.ff973c8000001p+52 -> -0x1.ff973c7ffffffp+10
 # ... and where neither are.
 floordiv 0x1.ff2e8e6fb6a62p+158 0x1.ff973c8000001p+52 -> 0x1.ff973c7ffffffp+105 Inexact
 floordiv -0x1.ff2e8e6fb6a62p+158 0x1.ff973c8000001p+52 -> -0x1.ff973c7ffffffp+105 Inexact
+
+#### Halfway cases: exact quotient is within 1 of a halfway case.
+# Exact quotient is 0x1.b6cb791cacbf37ffffffffffffb6de167b388b7fc8b3666a53bb....p+105
+# floordiv result is 1 smaller than halfway case, rounds down (towards zero)
+floordiv 0x1.800000000003bp+158 0x1.c0104a4a58bd7p+52 -> 0x1.b6cb791cacbf3p+105 Inexact
+# floordiv result *is* halfway case, rounds down (away from zero)
+floordiv -0x1.800000000003bp+158 0x1.c0104a4a58bd7p+52 -> -0x1.b6cb791cacbf4p+105 Inexact
+
+# Exact quotient is 0x1.98aa85ad41b278000000000000441c6b9ce0480bae415da0f245....p+105
+# floordiv result *is* halfway case, rounds up (away from zero)
+floordiv 0x1.8000000000021p+158 0x1.e118cf408df51p+52 -> 0x1.98aa85ad41b28p+105 Inexact
+# floordiv result one smaller than halfway case; rounds down (away from zero)
+floordiv -0x1.8000000000021p+158 0x1.e118cf408df51p+52 -> -0x1.98aa85ad41b28p+105 Inexact
+
 
 #### Check that the rounding mode is being respected.
 floordiv 0x1p53 0x0.fffffffffffff8p0 -> 0x1p53 Inexact

--- a/bigfloat/test/test_bigfloat.py
+++ b/bigfloat/test/test_bigfloat.py
@@ -333,7 +333,7 @@ class BigFloatTests(unittest.TestCase):
 
                 self.assertEqual(
                     actual_result, expected_result,
-                    msg="failure for x = {0}, y = {0}".format(x, y)
+                    msg="failure for x = {0!r}, y = {0!r}".format(x, y)
                 )
 
     def test_binary_operations(self):

--- a/bigfloat/test/test_bigfloat.py
+++ b/bigfloat/test/test_bigfloat.py
@@ -331,7 +331,10 @@ class BigFloatTests(unittest.TestCase):
                 except OverflowError:
                     expected_result = float('inf') if x_frac / y_frac > 0 else float('-inf')
 
-                self.assertEqual(actual_result, expected_result)
+                self.assertEqual(
+                    actual_result, expected_result,
+                    msg="failure for x = {0}, y = {0}".format(x, y)
+                )
 
     def test_binary_operations(self):
         # check that BigFloats can be combined with themselves,

--- a/bigfloat/test/test_bigfloat.py
+++ b/bigfloat/test/test_bigfloat.py
@@ -245,7 +245,7 @@ class BigFloatTests(unittest.TestCase):
     def test_arithmetic_functions(self):
         # test add, mul, div, sub, pow, mod
         test_precisions = [2, 10, 23, 24, 52, 53, 54, 100]
-        fns = [add, sub, mul, div, pow]
+        fns = [add, sub, mul, div, pow, floordiv]
         # mod function only exists for MPFR version >= 2.4.0
         if (MPFR_VERSION_MAJOR, MPFR_VERSION_MINOR) >= (2, 4):
             fns.append(mod)
@@ -341,13 +341,13 @@ class BigFloatTests(unittest.TestCase):
 
     def test_binary_operations(self):
         # check that BigFloats can be combined with themselves,
-        # and with integers and floats, using the 6 standard
-        # arithmetic operators:  +, -, *, /, **, %
+        # and with integers and floats, using the standard
+        # arithmetic operators:  +, -, *, /, **, %, //
 
         x = BigFloat('17.29')
         other_values = [2, 3, 1.234, BigFloat('0.678'), False]
         test_precisions = [2, 20, 53, 2000]
-        operations = [operator.add, operator.mul,
+        operations = [operator.add, operator.mul, operator.floordiv,
                       operator.sub, operator.pow, operator.truediv]
         # operator.div only defined for Python 2
         if sys.version_info < (3,):

--- a/bigfloat/test/test_bigfloat.py
+++ b/bigfloat/test/test_bigfloat.py
@@ -309,7 +309,7 @@ class BigFloatTests(unittest.TestCase):
                 y = float.fromhex(yhex)
                 x_frac = fractions.Fraction(*x.as_integer_ratio())
                 y_frac = fractions.Fraction(*y.as_integer_ratio())
-                expected_result = float(x_frac // y_frac)
+                expected_result = BigFloat(x_frac // y_frac)
                 actual_result = floordiv(x, y)
                 self.assertEqual(actual_result, expected_result)
 

--- a/bigfloat/test/test_bigfloat.py
+++ b/bigfloat/test/test_bigfloat.py
@@ -779,6 +779,22 @@ class BigFloatTests(unittest.TestCase):
         with self.assertRaises(TypeError):
             BigFloat(1j)
 
+    def test_divmod(self):
+        x = BigFloat.exact(1729)
+        y = BigFloat.exact(53)
+
+        q, r = divmod(x, y)
+        self.assertIsInstance(q, BigFloat)
+        self.assertIsInstance(r, BigFloat)
+        self.assertEqual(q, BigFloat.exact(1729 // 53))
+        self.assertEqual(r, BigFloat.exact(1729 % 53))
+
+        q, r = divmod(-x, y)
+        self.assertIsInstance(q, BigFloat)
+        self.assertIsInstance(r, BigFloat)
+        self.assertEqual(q, BigFloat.exact(-1729 // 53))
+        self.assertEqual(r, BigFloat.exact(-1729 % 53))
+
     def test_exact_context_independent(self):
         with Context(emin=-1, emax=1):
             x = BigFloat.exact(123456)

--- a/bigfloat/test/test_bigfloat.py
+++ b/bigfloat/test/test_bigfloat.py
@@ -284,57 +284,6 @@ class BigFloatTests(unittest.TestCase):
                         self.assertLess(y3, 1)
                         self.assertLess(1, x3)
 
-    def test__reround(self):
-        from bigfloat.core import _reround
-        import mpfr
-
-        # Take 10 bits of precision; round to 7, and then to 6 bits using
-        # reround; check that the effect is the same as rounding directly
-        # to 6 bits.
-
-        def test_n(n, rnd, rnd_intermediate):
-            # n an integer, 512 <= abs(n) <= 1024, say.
-
-            # Initialize variables.
-            input = mpfr.Mpfr_t()
-            intermediate = mpfr.Mpfr_t()
-            result_single_round = mpfr.Mpfr_t()
-            result_double_round = mpfr.Mpfr_t()
-            mpfr.mpfr_init2(input, 10)
-            mpfr.mpfr_init2(intermediate, 7)
-            mpfr.mpfr_init2(result_single_round, 6)
-            mpfr.mpfr_init2(result_double_round, 6)
-
-            # Input.
-            ternary = mpfr.mpfr_set_si(input, n, mpfr.MPFR_RNDN)
-            assert ternary == 0
-
-            # Result via double round.
-            ternary = mpfr.mpfr_set(intermediate, input, rnd_intermediate)
-            ternary_double_round = _reround(
-                result_double_round, intermediate, ternary, rnd)
-
-            # Result via single round.
-            ternary_single_round = mpfr.mpfr_set(
-                result_single_round, input, rnd)
-
-            self.assertEqual(ternary_single_round, ternary_double_round)
-            self.assertTrue(
-                mpfr.mpfr_equal_p(result_single_round, result_double_round))
-
-        ALL_ROUNDING_MODES = [
-            mpfr.MPFR_RNDN,
-            mpfr.MPFR_RNDA,
-            mpfr.MPFR_RNDZ,
-            mpfr.MPFR_RNDU,
-            mpfr.MPFR_RNDD,
-        ]
-
-        for rnd in ALL_ROUNDING_MODES:
-            for rnd2 in ALL_ROUNDING_MODES:
-                for n in range(512, 1025):
-                    test_n(754, rnd, rnd2)
-
     def test_floordiv(self):
         x = BigFloat(2.3)
         y = BigFloat(1.2)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -101,7 +101,7 @@ Whether installing ``bigfloat`` from source or from the Python Package Index,
 you will need to have both the GMP and MPFR libraries already installed on your
 system, along with the include files for those libraries.  See the `MPFR
 homepage <http://www.mpfr.org>`_ and the `GMP homepage <http://gmplib.org>`_
-for more information about these libraries.  Currently, MPFR version 2.3.0 or
+for more information about these libraries.  Currently, MPFR version 3.0.0 or
 later is required.
 
 On Ubuntu, prerequisites can be installed with::

--- a/docs/source/reference/index.rst
+++ b/docs/source/reference/index.rst
@@ -110,11 +110,11 @@ deviations from expected behaviour.
   current context, and has the property that ``eval(repr(x))``
   recovers ``x`` exactly.
 
-* The '+' ,'-', '*', '/', '//' and '**' binary operators are supported.  For
-  MPFR version >= 2.4.0, the '%' operation is also supported.  The '/' operator
-  implements true division, regardless of whether ``from __future__ import
-  division`` is in effect or not.  The result of '%' has the same sign as the
-  first argument, not the second.
+* The '+' ,'-', '*', '/', '//', '%' and '**' binary operators are supported.
+  The '/' operator implements true division, regardless of whether ``from
+  __future__ import division`` is in effect or not.  The result of '%' has the
+  same sign as the second argument, so follows the existing Python semantics
+  for '%' on Python floats.
 
 * For the above operators, mixed-type operations involving a :class:`BigFloat`
   and an integer or float are permitted. These behave as though the non

--- a/docs/source/reference/index.rst
+++ b/docs/source/reference/index.rst
@@ -103,23 +103,23 @@ Special methods
 """""""""""""""
 
 The :class:`BigFloat` type has a full complement of special methods.
-Here are some brief notes on those methods, indicating some possible
+Here are some brief notes on those methods, indicating possible
 deviations from expected behaviour.
 
 * The repr of a :class:`BigFloat` instance ``x`` is independent of the
   current context, and has the property that ``eval(repr(x))``
   recovers ``x`` exactly.
 
-* The '+' ,'-', '*', '/' and '**' binary operators are supported, and
-  mixed-type operations involving a :class:`BigFloat` and an integer
-  or float are permitted.  For MPFR version >= 2.4.0, the '%' is also
-  supported.  Mixed-type operations behave as though the non
-  :class:`BigFloat` operand is first converted to a :class:`BigFloat`
-  with no loss of accuracy.  The '/' operator implements true
-  division, regardless of whether 'from __future__ import division' is
-  in effect or not.  The result of '%' has the same sign as the first
-  argument, not the second.  Floor division is not currently
-  implemented.
+* The '+' ,'-', '*', '/', '//' and '**' binary operators are supported.  For
+  MPFR version >= 2.4.0, the '%' operation is also supported.  The '/' operator
+  implements true division, regardless of whether ``from __future__ import
+  division`` is in effect or not.  The result of '%' has the same sign as the
+  first argument, not the second.
+
+* For the above operators, mixed-type operations involving a :class:`BigFloat`
+  and an integer or float are permitted. These behave as though the non
+  :class:`BigFloat` operand is first converted to a :class:`BigFloat` with no
+  loss of accuracy.
 
 * The '+' and '-' unary operators and built-in :func:`abs` function
   are supported.  Note that these all round to the current context; in
@@ -476,6 +476,7 @@ Arithmetic functions
 .. autofunction:: sub
 .. autofunction:: mul
 .. autofunction:: div
+.. autofunction:: floordiv
 .. autofunction:: pow
 .. autofunction:: mod
 

--- a/docs/source/reference/index.rst
+++ b/docs/source/reference/index.rst
@@ -56,7 +56,7 @@ zero, and NaNs.
 
       In contrast to ``abs(self)``, ``self.copy_abs()`` makes no use of the
       context, and the result has the same precision as the original.
-      
+
    .. method:: copy_neg(self)
 
       Return a copy of *self* with the opposite sign bit.
@@ -443,12 +443,12 @@ Rounding modes
 .. data:: ROUND_TOWARD_POSITIVE
 
    The number to be rounded is mapped to the nearest representable value
-   greater than or equal to the original number. 
+   greater than or equal to the original number.
 
 .. data:: ROUND_TOWARD_NEGATIVE
 
    The number to be rounded is mapped to the nearest representable value
-   less than or equal to the original number. 
+   less than or equal to the original number.
 
 
 .. _standard functions:
@@ -478,7 +478,7 @@ Arithmetic functions
 .. autofunction:: div
 .. autofunction:: floordiv
 .. autofunction:: pow
-.. autofunction:: mod
+.. autofunction:: fmod
 
 .. autofunction:: remainder
 
@@ -619,7 +619,7 @@ comparison operators.
 .. autofunction:: greaterequal
 .. autofunction:: less
 .. autofunction:: lessequal
-.. autofunction:: equal 
+.. autofunction:: equal
 .. autofunction:: notequal
 
 .. versionadded:: 0.4

--- a/docs/source/reference/index.rst
+++ b/docs/source/reference/index.rst
@@ -476,9 +476,10 @@ Arithmetic functions
 .. autofunction:: sub
 .. autofunction:: mul
 .. autofunction:: div
-.. autofunction:: floordiv
 .. autofunction:: pow
 .. autofunction:: fmod
+.. autofunction:: floordiv
+.. autofunction:: mod
 
 .. autofunction:: remainder
 

--- a/docs/source/tutorial/index.rst
+++ b/docs/source/tutorial/index.rst
@@ -146,10 +146,9 @@ prettier, but doesn't supply enough information to recover that
 Arithmetic on :class:`BigFloat` instances
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-All the usual arithmetic operations, with the exception of floor
-division, apply to :class:`BigFloat` instances, and those instances can be
-freely mixed with integers and floats (but not strings!) in those
-operations:
+All the usual arithmetic operations apply to :class:`BigFloat` instances, and
+those instances can be freely mixed with integers and floats (but not strings!)
+in those operations:
 
    >>> BigFloat(1234)/3
    BigFloat.exact('411.33333333333331', precision=53)

--- a/mpfr.pyx
+++ b/mpfr.pyx
@@ -519,7 +519,7 @@ def mpfr_set_inf(Mpfr_t op not None, int sign):
     Set the variable x to infinity.  x is set to positive infinity if the sign
     is nonnegative, and negative infinity otherwise.
 
-    Note the unusual sign convention here: most MPFR function that deal with
+    Note the unusual sign convention here: most MPFR functions that deal with
     signs use a nonzero value (or True) to indicate a negative number, and zero
     to indiciate a positive number.
 
@@ -533,7 +533,7 @@ def mpfr_set_zero(Mpfr_t op not None, int sign):
     Set the variable x to zero.  x is set to positive zero if the sign is
     nonnegative, and negative zero otherwise.
 
-    Note the unusual sign convention here: most MPFR function that deal with
+    Note the unusual sign convention here: most MPFR functions that deal with
     signs use a nonzero value (or True) to indicate a negative number, and zero
     to indiciate a positive number.
 


### PR DESCRIPTION
This PR:
- implements floor division, Python-style modulus, and divmod.
- switches the implementation of % on BigFloats to use Python-style semantics for negative operands.
- renames the old `mod` function to `fmod`.
- adds new `mod` and `floordiv` functions for the new `%` semantics and the `//` operation, respectively.
- removes the checks for MPFR version >= 2.4.0; we now require version 3.0 or later.