### PR TITLE
Make the default context equal to IEEE 754 quadruple precision.

### DIFF
--- a/bigfloat/context.py
+++ b/bigfloat/context.py
@@ -39,7 +39,8 @@ EMIN_MAX = min(mpfr.MPFR_EMAX_DEFAULT, mpfr.mpfr_get_emin_max())
 
 
 class Context(object):
-    """Information about output format and rounding mode.
+    """
+    Information about output format and rounding mode.
 
     A context provides information about the output format for a
     particular operation (target precision, minimum and maximum

--- a/bigfloat/context.py
+++ b/bigfloat/context.py
@@ -60,7 +60,8 @@ class Context(object):
     'rounding' is the rounding mode.
 
     Note that exponent values are relative to a significand scaled to have
-    absolute value in the range [0.5, 1.0).
+    absolute value in the range [0.5, 1.0), and that ``emin`` takes
+    the subnormal range into account when ``subnormalize`` is ``True``.
     """
     # Contexts are supposed to be immutable.  We make the attributes
     # of a Context private, and provide properties to access them in

--- a/bigfloat/context.py
+++ b/bigfloat/context.py
@@ -172,11 +172,11 @@ class Context(object):
 
 # DefaultContext is the context that the module always starts with.
 DefaultContext = Context(
-    precision=53,
     rounding=ROUND_TIES_TO_EVEN,
-    emax=EMAX_MAX,
-    emin=EMIN_MIN,
-    subnormalize=False,
+    precision=113,
+    emax=16384,
+    emin=-16493,
+    subnormalize=True,
 )
 
 # EmptyContext is useful for situations where a context is

--- a/bigfloat/context.py
+++ b/bigfloat/context.py
@@ -39,6 +39,28 @@ EMIN_MAX = min(mpfr.MPFR_EMAX_DEFAULT, mpfr.mpfr_get_emin_max())
 
 
 class Context(object):
+    """Information about output format and rounding mode.
+
+    A context provides information about the output format for a
+    particular operation (target precision, minimum and maximum
+    exponents, and whether to use gradual underflow), and the
+    rounding mode used to round the true result to that format.
+
+    Attributes
+    ----------
+    'precision' is the precision in bits (for example, 53 for
+    standard IEEE double precision).
+    'subnormalize' is True for formats that have gradual underflow
+    and False otherwise.
+    'emin' is the minimum exponent; for example, -1073 for IEEE 754
+    double precision
+    'emax' is the maximum exponent; for example, 1024 for IEEE 754
+    double precision.
+    'rounding' is the rounding mode.
+
+    Note that exponent values are relative to a significand scaled to have
+    absolute value in the range [0.5, 1.0).
+    """
     # Contexts are supposed to be immutable.  We make the attributes
     # of a Context private, and provide properties to access them in
     # order to discourage users from trying to set the attributes
@@ -149,15 +171,25 @@ class Context(object):
 # some useful contexts
 
 # DefaultContext is the context that the module always starts with.
-DefaultContext = Context(precision=53,
-                         rounding=ROUND_TIES_TO_EVEN,
-                         emax=EMAX_MAX,
-                         emin=EMIN_MIN,
-                         subnormalize=False)
+DefaultContext = Context(
+    precision=53,
+    rounding=ROUND_TIES_TO_EVEN,
+    emax=EMAX_MAX,
+    emin=EMIN_MIN,
+    subnormalize=False,
+)
 
 # EmptyContext is useful for situations where a context is
 # required, but no change to the current context is desirable
 EmptyContext = Context()
+
+# WideExponentContext has the largest exponent range allowed
+# by MPFR; precision and rounding mode are not specified.
+WideExponentContext = Context(
+    emax=EMAX_MAX,
+    emin=EMIN_MIN,
+    subnormalize=False,
+)
 
 # thread local variables:
 #   __bigfloat_context__: current context
@@ -237,7 +269,6 @@ def extra_precision(prec):
     BigFloat.exact('0.88622692545275801364912', precision=73)
 
     """
-
     c = getcontext()
     return Context(precision=c.precision + prec)
 

--- a/bigfloat/core.py
+++ b/bigfloat/core.py
@@ -36,9 +36,10 @@ from bigfloat.rounding_mode import (
 
 from bigfloat.context import (
     Context,
-    DefaultContext,
     EmptyContext,
+    WideExponentContext,
 
+    RoundTiesToEven,
     RoundTowardPositive,
     RoundTowardNegative,
 
@@ -312,7 +313,6 @@ class BigFloat(mpfr.Mpfr_t):
 
         This constructor makes no use of the current context.
         """
-
         # figure out precision to use
         if isinstance(value, six.string_types):
             if precision is None:
@@ -333,10 +333,15 @@ class BigFloat(mpfr.Mpfr_t):
                 raise TypeError("Can't convert argument %s of type %s "
                                 "to BigFloat" % (value, type(value)))
 
-        # use Default context, with given precision
+        # Use unlimited exponents, with given precision.
         with _saved_flags():
             set_flagstate(set())  # clear all flags
-            with DefaultContext + Context(precision=precision):
+            context = (
+                WideExponentContext +
+                Context(precision=precision) +
+                RoundTiesToEven
+            )
+            with context:
                 result = BigFloat(value)
             if test_flag(Overflow):
                 raise ValueError("value too large to represent as a BigFloat")

--- a/bigfloat/test/test_bigfloat.py
+++ b/bigfloat/test/test_bigfloat.py
@@ -47,12 +47,12 @@ from bigfloat import (
     EMIN_MIN, EMAX_MAX,
 
     # context constants...
-    DefaultContext,
     half_precision, single_precision,
     double_precision, quadruple_precision,
     RoundTiesToEven, RoundTowardZero,
     RoundTowardPositive, RoundTowardNegative,
     RoundAwayFromZero,
+    ROUND_TIES_TO_EVEN,
 
     # ... and functions
     IEEEContext, precision,
@@ -67,9 +67,6 @@ from bigfloat import (
     # standard arithmetic functions
     add, sub, mul, div, fmod, pow,
     sqrt, floordiv, mod,
-
-    # Version information
-    MPFR_VERSION_MAJOR, MPFR_VERSION_MINOR,
 
     # 5.5 Basic Arithmetic Functions
     root,
@@ -105,6 +102,16 @@ if sys.version_info < (3,):
     long_integer_type = long  # noqa
 else:
     long_integer_type = int
+
+
+# Context at the start of each test method.
+DefaultTestContext = Context(
+    precision=53,
+    rounding=ROUND_TIES_TO_EVEN,
+    emax=EMAX_MAX,
+    emin=EMIN_MIN,
+    subnormalize=False,
+)
 
 
 def diffBigFloat(x, y, match_precisions=True):
@@ -186,7 +193,7 @@ class PoorObject(object):
 
 class BigFloatTests(unittest.TestCase):
     def setUp(self):
-        setcontext(DefaultContext)
+        setcontext(DefaultTestContext)
 
     def test_version(self):
         self.assertIsInstance(__version__, str)
@@ -1901,7 +1908,7 @@ class FlagTests(unittest.TestCase):
 
 class ABCTests(unittest.TestCase):
     def setUp(self):
-        setcontext(DefaultContext)
+        setcontext(DefaultTestContext)
 
 
 def mpfr_set_str2(rop, s, base, rnd):

--- a/bigfloat/test/test_context.py
+++ b/bigfloat/test/test_context.py
@@ -25,7 +25,6 @@ from bigfloat.context import (
     setcontext,
     getcontext,
     Context,
-    DefaultContext,
 
     _temporary_exponent_bounds,
 )
@@ -48,9 +47,6 @@ all_rounding_modes = [
 
 
 class ContextTests(unittest.TestCase):
-    def setUp(self):
-        setcontext(DefaultContext)
-
     def test__temporary_exponent_bounds(self):
         # Failed calls to _temporary_exponent_bounds shouldn't affect emin or
         # emax.
@@ -84,7 +80,13 @@ class ContextTests(unittest.TestCase):
         self.assertEqual(mpfr.mpfr_get_emax(), original_emax)
 
     def test_attributes(self):
-        c = DefaultContext
+        c = Context(
+            emin=-999,
+            emax=999,
+            precision=100,
+            subnormalize=True,
+            rounding=ROUND_TIES_TO_EVEN,
+        )
         self.assertIsInstance(c.precision, int)
         self.assertIsInstance(c.emax, int)
         self.assertIsInstance(c.emin, int)
@@ -98,8 +100,8 @@ class ContextTests(unittest.TestCase):
     def test_hashable(self):
         # create equal but non-identical contexts
         c1 = Context(emin=-999, emax=999, precision=100,
-                     subnormalize=True, rounding=mpfr.MPFR_RNDU)
-        c2 = (Context(emax=999, emin=-999, rounding=mpfr.MPFR_RNDU) +
+                     subnormalize=True, rounding=ROUND_TOWARD_POSITIVE)
+        c2 = (Context(emax=999, emin=-999, rounding=ROUND_TOWARD_POSITIVE) +
               Context(precision=100, subnormalize=True))
         self.assertEqual(hash(c1), hash(c2))
         self.assertEqual(c1, c2)
@@ -108,18 +110,18 @@ class ContextTests(unittest.TestCase):
 
         # distinct contexts
         d1 = Context(emin=-999, emax=999, precision=100,
-                     subnormalize=True, rounding=mpfr.MPFR_RNDU)
+                     subnormalize=True, rounding=ROUND_TOWARD_POSITIVE)
         d2 = Context(emin=-999, emax=999, precision=101,
-                     subnormalize=True, rounding=mpfr.MPFR_RNDU)
+                     subnormalize=True, rounding=ROUND_TOWARD_POSITIVE)
         self.assertIs(d1 != d2, True)
         self.assertIs(d1 == d2, False)
 
     def test_with(self):
         # check use of contexts in with statements
         c = Context(emin=-123, emax=456, precision=1729,
-                    subnormalize=True, rounding=mpfr.MPFR_RNDU)
+                    subnormalize=True, rounding=ROUND_TOWARD_POSITIVE)
         d = Context(emin=0, emax=10585, precision=20,
-                    subnormalize=False, rounding=mpfr.MPFR_RNDD)
+                    subnormalize=False, rounding=ROUND_TOWARD_NEGATIVE)
 
         with c:
             # check nested with

--- a/bigfloat/test/test_formatting.py
+++ b/bigfloat/test/test_formatting.py
@@ -23,14 +23,18 @@ else:
 
 from bigfloat import (
     BigFloat,
-    DefaultContext,
+    double_precision,
+    RoundTiesToEven,
     setcontext,
 )
 
 
+DefaultTestContext = double_precision + RoundTiesToEven
+
+
 class TestFormatting(unittest.TestCase):
     def setUp(self):
-        setcontext(DefaultContext)
+        setcontext(DefaultTestContext)
 
     def test_format(self):
         # Fixed precision formatting.


### PR DESCRIPTION
This PR replaces the current default context with IEEE 754 quadruple precision, so that:
- users get extra precision out of the box (there's little value in the original 53-bit precision, since floats already provide that)
- the exponent min and max are consistent across platforms (the previous values were based on the MPFR limits, which may vary across platforms).

Closes #17.
