### PR TITLE
Support Python 2.7 & 3.4+, drop EOL versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,17 @@
 language: python
 python:
-  - 2.6
   - 2.7
-  - 3.2
-  - 3.3
   - 3.4
+  - 3.5
+  - 3.6
 install:
   - sudo apt-get update
   - sudo apt-get install libmpfr-dev
-  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install unittest2; fi
   - pip install Cython
   - pip install six
 script:
   - python setup.py build_ext --inplace
-  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then unit2 discover -v; else python -m unittest discover -v; fi
+  - python -m unittest discover -v
 notifications:
   email:
     - dickinsm@gmail.com

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -1,8 +1,8 @@
 Prerequisites
 -------------
 
-This package requires Python 2.6 or later.  The `MPFR <mpfr library_>`_ and
-`GMP <gmp library_>`_ libraries will need to be already installed on your
+This package requires Python 2.7 or 3.4 or later.  The `MPFR <mpfr library_>`_
+and `GMP <gmp library_>`_ libraries will need to be already installed on your
 system, along with any necessary development headers for both of those
 libraries.  On Linux, look for a package named something like ``libmpfr-dev``
 or ``mpfr-devel``, along with similarly named packages for GMP.
@@ -48,11 +48,6 @@ named something like ``bigfloat-0.4.0``.
 
       $ python -m unittest discover bigfloat
 
-    Note that test discovery requires Python >= 2.7.  If you're on Python 2.6,
-    you can use the `unittest2`_ package instead.  For example::
-
-      $ unit2-2.6 discover bigfloat
-
 (3) To check that everything's working, compute the square root of 2 to 1000
     bits of precision::
 
@@ -68,4 +63,3 @@ created can now be deleted.
 
 .. _gmp library: http://gmplib.org
 .. _mpfr library: http://www.mpfr.org
-.. _unittest2: http://pypi.python.org/pypi/unittest2

--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ idea::
 Features
 --------
 
-- Supports Python 2 (version 2.7) and Python 3 (version 3.2 or later).
+- Supports Python 2 (version 2.7) and Python 3 (version 3.4 or later).
 
 - Exactly reproducible correctly-rounded results across platforms;
   precisely-defined semantics compatible with the IEEE 754-2008 standard.

--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ idea::
 Features
 --------
 
-- Supports Python 2 (version 2.6 or later) and Python 3 (version 3.2 or later).
+- Supports Python 2 (version 2.7) and Python 3 (version 3.2 or later).
 
 - Exactly reproducible correctly-rounded results across platforms;
   precisely-defined semantics compatible with the IEEE 754-2008 standard.

--- a/bigfloat/core.py
+++ b/bigfloat/core.py
@@ -432,7 +432,7 @@ class BigFloat(mpfr.Mpfr_t):
             # minimum field width ourselves in post-processing, along with PEP
             # 3101-style filling and padding.
             if spec['precision'] is not None:
-                prec = '.{0}'.format(spec['precision'])
+                prec = '.{}'.format(spec['precision'])
             else:
                 prec = ''
             mpfr_format_template = "%{alternate}{prec}R{rounding}{type}"

--- a/bigfloat/core.py
+++ b/bigfloat/core.py
@@ -883,7 +883,7 @@ Underflow = 'Underflow'
 NanFlag = 'NanFlag'
 ZeroDivision = 'ZeroDivision'
 
-_all_flags = set([Inexact, Overflow, Underflow, NanFlag, ZeroDivision])
+_all_flags = {Inexact, Overflow, Underflow, NanFlag, ZeroDivision}
 
 _flag_translate = {
     'underflow': Underflow,

--- a/bigfloat/test/test_bigfloat.py
+++ b/bigfloat/test/test_bigfloat.py
@@ -1889,18 +1889,18 @@ class FlagTests(unittest.TestCase):
     def test_overflow(self):
         set_flagstate(set())  # clear flags
         exp(BigFloat(1e308))
-        self.assertEqual(get_flagstate(), set([Inexact, Overflow]))
+        self.assertEqual(get_flagstate(), {Inexact, Overflow})
 
     def test_divide_by_zero(self):
         # Clear all flags.
         set_flagstate(set())
         self.assertEqual(get_flagstate(), set())
         BigFloat(2) / BigFloat(0)
-        self.assertEqual(get_flagstate(), set([ZeroDivision]))
+        self.assertEqual(get_flagstate(), {ZeroDivision})
         # Flag should be sticky, so after a simple exact operation, it
         # should still be set.
         BigFloat(1) * BigFloat(3)
-        self.assertEqual(get_flagstate(), set([ZeroDivision]))
+        self.assertEqual(get_flagstate(), {ZeroDivision})
 
 
 class ABCTests(unittest.TestCase):

--- a/bigfloat/test/test_bigfloat.py
+++ b/bigfloat/test/test_bigfloat.py
@@ -26,10 +26,7 @@ import random
 import struct
 import sys
 import types
-if sys.version_info < (2, 7):
-    import unittest2 as unittest
-else:
-    import unittest
+import unittest
 
 import bigfloat.core
 

--- a/bigfloat/test/test_context.py
+++ b/bigfloat/test/test_context.py
@@ -15,11 +15,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with the bigfloat package.  If not, see <http://www.gnu.org/licenses/>.
 
-import sys
-if sys.version_info < (2, 7):
-    import unittest2 as unittest
-else:
-    import unittest
+import unittest
 
 import mpfr
 from bigfloat.context import (

--- a/bigfloat/test/test_formatting.py
+++ b/bigfloat/test/test_formatting.py
@@ -15,11 +15,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with the bigfloat package.  If not, see <http://www.gnu.org/licenses/>.
 
-import sys
-if sys.version_info < (2, 7):
-    import unittest2 as unittest
-else:
-    import unittest
+import unittest
 
 from bigfloat import (
     BigFloat,

--- a/bigfloat/test/test_mpfr.py
+++ b/bigfloat/test/test_mpfr.py
@@ -1127,7 +1127,7 @@ class TestMpfr(unittest.TestCase):
             self.assertEqual(
                 actual_output,
                 expected_output,
-                msg='{0}'.format(fn),
+                msg='{}'.format(fn),
             )
 
     def test_lgamma(self):
@@ -1333,8 +1333,8 @@ class TestMpfr(unittest.TestCase):
                 actual_output,
                 expected_output,
                 msg=(
-                    "Unexpected result for {0}({1}): expected {2}, "
-                    "got {3}.".format(
+                    "Unexpected result for {}({}): expected {}, "
+                    "got {}.".format(
                         fn.__name__, input, expected_output, actual_output,
                     ),
                 ),
@@ -1361,8 +1361,8 @@ class TestMpfr(unittest.TestCase):
                 actual_output,
                 expected_output,
                 msg=(
-                    "Unexpected result for {0}({1}): expected {2}, "
-                    "got {3}.".format(
+                    "Unexpected result for {}({}): expected {}, "
+                    "got {}.".format(
                         fn.__name__, input, expected_output, actual_output,
                     ),
                 ),

--- a/bigfloat/test/test_mpfr.py
+++ b/bigfloat/test/test_mpfr.py
@@ -16,11 +16,7 @@
 # along with the bigfloat package.  If not, see <http://www.gnu.org/licenses/>.
 
 import contextlib
-import sys
-if sys.version_info < (2, 7):
-    import unittest2 as unittest
-else:
-    import unittest
+import unittest
 
 from mpfr import (
     _LONG_MIN, _LONG_MAX,

--- a/bigfloat/test/test_rounding_mode.py
+++ b/bigfloat/test/test_rounding_mode.py
@@ -15,11 +15,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with the bigfloat package.  If not, see <http://www.gnu.org/licenses/>.
 
-import sys
-if sys.version_info < (2, 7):
-    import unittest2 as unittest
-else:
-    import unittest
+import unittest
 
 import mpfr as mpfr
 from bigfloat.rounding_mode import (

--- a/bigfloat/version.py
+++ b/bigfloat/version.py
@@ -21,14 +21,14 @@ patch = 0
 prerelease = 'dev'
 
 if prerelease:
-    __version__ = "{0}.{1}.{2}-{3}".format(major, minor, patch, prerelease)
+    __version__ = "{}.{}.{}-{}".format(major, minor, patch, prerelease)
 else:
-    __version__ = "{0}.{1}.{2}".format(major, minor, patch)
+    __version__ = "{}.{}.{}".format(major, minor, patch)
 
 # Release and version for Sphinx purposes.
 
 # The short X.Y version.
-version = "{0}.{1}".format(major, minor)
+version = "{}.{}".format(major, minor)
 
 # The full version, including patchlevel and alpha/beta/rc tags.
 release = __version__

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -30,7 +30,7 @@ subnormals.
 Features
 --------
 
-- Supports Python 2 (version 2.6 or later) and Python 3 (version 3.2 or later).
+- Supports Python 2 (version 2.7) and Python 3 (version 3.4 or later).
 
 - Exactly reproducible correctly-rounded results across platforms;
   precisely-defined semantics compatible with the IEEE 754-2008 standard.
@@ -93,8 +93,8 @@ Development sources can be checked out from the project's `GitHub page
 Prerequisites
 ^^^^^^^^^^^^^
 
-The :mod:`bigfloat` package works with Python 2 (version 2.6 or later) or
-Python 3 (version 3.2 or later).  It uses a single codebase for both Python
+The :mod:`bigfloat` package works with Python 2 (version 2.7) or
+Python 3 (version 3.4 or later).  It uses a single codebase for both Python
 dialects, so the same source works on both dialects of Python.
 
 Whether installing ``bigfloat`` from source or from the Python Package Index,

--- a/examples/contfrac.py
+++ b/examples/contfrac.py
@@ -115,4 +115,4 @@ print("{0:4s} {1:15s}".format("====", "==============="))
 for b, n in sorted(marks_results.items()):
     print("{0:4d} {1:15d}".format(b, n))
 results_match = marks_results == pauls_results
-print("Results match Paul Zimmerman's: {0}".format(results_match))
+print("Results match Paul Zimmerman's: {}".format(results_match))

--- a/fabfile.py
+++ b/fabfile.py
@@ -4,9 +4,6 @@ from fabric.api import local, lcd
 PYTHON = "python"
 COVERAGE = "coverage"
 
-# Unittest 2 runner for Python 2.6.
-UNIT2 = "unit2-2.6"
-
 # Paths for mpfr and gmp libraries and include files.
 LIBRARY_PATH = "/opt/local/lib"
 INCLUDE_PATH = "/opt/local/include"
@@ -55,10 +52,7 @@ def clean():
 
 
 def run_tests(python=PYTHON):
-    if python == "python2.6":
-        unittest = UNIT2
-    else:
-        unittest = "{python} -m unittest".format(python=python)
+    unittest = "{python} -m unittest".format(python=python)
     local("{unittest} discover -v .".format(unittest=unittest))
 
 
@@ -94,9 +88,8 @@ def docs(python=PYTHON):
 
 
 def test_all():
-    """Run tests on Python versions 2.6 through 3.4."""
-    test(python="python2.6")
+    """Run tests on Python versions 2.7 and 3.4 through 3.6."""
     test(python="python2.7")
-    test(python="python3.2")
-    test(python="python3.3")
     test(python="python3.4")
+    test(python="python3.5")
+    test(python="python3.6")

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ idea::
 Features
 --------
 
-- Supports Python 2 (version 2.6 or later) and Python 3 (version 3.2 or later).
+- Supports Python 2 (version 2.7) and Python 3 (version 3.4 or later).
 
 - Exactly reproducible correctly-rounded results across platforms;
   precisely-defined semantics compatible with the IEEE 754-2008 standard.
@@ -236,12 +236,11 @@ Intended Audience :: Science/Research
 License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)
 Operating System :: OS Independent
 Programming Language :: Python :: 2
-Programming Language :: Python :: 2.6
 Programming Language :: Python :: 2.7
 Programming Language :: Python :: 3
-Programming Language :: Python :: 3.2
-Programming Language :: Python :: 3.3
 Programming Language :: Python :: 3.4
+Programming Language :: Python :: 3.5
+Programming Language :: Python :: 3.6
 Programming Language :: Python :: Implementation :: CPython
 Topic :: Scientific/Engineering :: Mathematics
 """.splitlines()


### PR DESCRIPTION
Fixes https://github.com/mdickinson/bigfloat/issues/74.

Here's the pip installs for bigfloat from PyPI for the last year:
```
$ pypinfo -d 365 --percent --pip bigfloat pyversion
python_version percent download_count
-------------- ------- --------------
2.7              63.2%          3,047
3.5              17.9%            865
3.6              13.9%            668
3.4               4.8%            230
3.3               0.1%              5
2.6               0.1%              4

```