### PR TITLE
Fix test failure with Mpfr 4.0

### DIFF
--- a/bigfloat/test/test_mpfr.py
+++ b/bigfloat/test/test_mpfr.py
@@ -376,7 +376,7 @@ class TestMpfr(unittest.TestCase):
         with self.assertRaises(ValueError):
             Mpfr(MPFR_PREC_MIN - 1)
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises((ValueError, OverflowError)):
             Mpfr(MPFR_PREC_MAX + 1)
 
     def test_constructor(self):

--- a/bigfloat/test/test_mpfr.py
+++ b/bigfloat/test/test_mpfr.py
@@ -22,6 +22,7 @@ from mpfr import (
     _LONG_MIN, _LONG_MAX,
 
     MPFR_RNDN, MPFR_RNDZ, MPFR_RNDU, MPFR_RNDD, MPFR_RNDA,
+    MPFR_PREC_MIN, MPFR_PREC_MAX,
 
     # Base extension type
     Mpfr_t,
@@ -373,7 +374,10 @@ class TestMpfr(unittest.TestCase):
             Mpfr(10, 11)
 
         with self.assertRaises(ValueError):
-            Mpfr(1)
+            Mpfr(MPFR_PREC_MIN - 1)
+
+        with self.assertRaises(ValueError):
+            Mpfr(MPFR_PREC_MAX + 1)
 
     def test_constructor(self):
         x = Mpfr(10)


### PR DESCRIPTION
There was one test failure with MPFR 4.0, due to the change of MPFR_PREC_MIN from 2 to 1. We had a test that checked that trying to initialize with precision 1 caused a ValueError.