### PR TITLE
Adjust supported Python versions: drop Python 3.4 support, add 3.7 and 3.8.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - 3.5
   - 3.6
   - 3.7
+  - 3.8
 install:
   - sudo apt-get update
   - sudo apt-get install libmpfr-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: python
+dist: xenial
 python:
   - 2.7
-  - 3.4
   - 3.5
   - 3.6
+  - 3.7
 install:
   - sudo apt-get update
   - sudo apt-get install libmpfr-dev

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,6 +33,11 @@ Changes
 
 - MPFR version 3.0.0 or later is required.
 
+- Support for Python 3.7 and 3.8 added.
+
+- Support for Python 3.4 has been dropped. Python 2.7, and Python 3.5 or later
+  are still supported.
+
 Bugfixes
 --------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,10 +33,10 @@ Changes
 
 - MPFR version 3.0.0 or later is required.
 
-- Support for Python 3.7 and 3.8 added.
+- Support for Python 3.7 and 3.8 added. (#81)
 
 - Support for Python 3.4 has been dropped. Python 2.7, and Python 3.5 or later
-  are still supported.
+  are still supported. (#81)
 
 Bugfixes
 --------

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -1,7 +1,7 @@
 Prerequisites
 -------------
 
-This package requires Python 2.7 or 3.4 or later.  The `MPFR <mpfr library_>`_
+This package requires Python 2.7 or 3.5 or later.  The `MPFR <mpfr library_>`_
 and `GMP <gmp library_>`_ libraries will need to be already installed on your
 system, along with any necessary development headers for both of those
 libraries.  On Linux, look for a package named something like ``libmpfr-dev``

--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ idea::
 Features
 --------
 
-- Supports Python 2 (version 2.7) and Python 3 (version 3.4 or later).
+- Supports Python 2 (version 2.7) and Python 3 (version 3.5 or later).
 
 - Exactly reproducible correctly-rounded results across platforms;
   precisely-defined semantics compatible with the IEEE 754-2008 standard.

--- a/bigfloat/test/test_bigfloat.py
+++ b/bigfloat/test/test_bigfloat.py
@@ -174,7 +174,7 @@ dummy_ops = [
 ]
 if sys.version_info < (3,):
     dummy_ops.extend(["div", "rdiv"])
-if sys.version_info >= (3, 5):
+if sys.version_info >= (3,):
     dummy_ops.extend(["matmul", "rmatmul"])
 
 for op in dummy_ops:
@@ -419,7 +419,7 @@ class BigFloatTests(unittest.TestCase):
         self.assertEqual(bf ** other, "rpow")
         if sys.version_info < (3,):
             self.assertEqual(operator.div(bf, other), "rdiv")
-        if sys.version_info >= (3, 5):
+        if sys.version_info >= (3,):
             self.assertEqual(operator.matmul(bf, other), "rmatmul")
 
         # Bitwise: &, ^, |, <<, >>
@@ -447,7 +447,7 @@ class BigFloatTests(unittest.TestCase):
             binary_ops.extend(
                 [operator.gt, operator.lt, operator.ge, operator.le])
 
-        if sys.version_info >= (3, 5):
+        if sys.version_info >= (3,):
             binary_ops.append(operator.matmul)
 
         bf = BigFloat(123)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -99,7 +99,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'bigfloat'
-copyright = '2009--2015 Mark Dickinson'
+copyright = '2009--2019, Mark Dickinson'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -30,7 +30,7 @@ subnormals.
 Features
 --------
 
-- Supports Python 2 (version 2.7) and Python 3 (version 3.4 or later).
+- Supports Python 2 (version 2.7) and Python 3 (version 3.5 or later).
 
 - Exactly reproducible correctly-rounded results across platforms;
   precisely-defined semantics compatible with the IEEE 754-2008 standard.
@@ -55,7 +55,7 @@ Here's a quick tour::
    BigFloat.exact('1.4142135623730950488016887242092', precision=100)
    >>> with precision(100):     # another way to get the same result
    ...     sqrt(2)
-   ... 
+   ...
    BigFloat.exact('1.4142135623730950488016887242092', precision=100)
    >>> my_context = precision(100) + RoundTowardPositive
    >>> my_context
@@ -64,7 +64,7 @@ Here's a quick tour::
    BigFloat.exact('1.4142135623730950488016887242108', precision=100)
    >>> with RoundTowardNegative: # a lower bound for zeta(2)
    ...     sum(1/sqr(n) for n in range(1, 10000))
-   ... 
+   ...
    BigFloat.exact('1.6448340618469506', precision=53)
    >>> zeta(2) # actual value, for comparison
    BigFloat.exact('1.6449340668482264', precision=53)
@@ -94,7 +94,7 @@ Prerequisites
 ^^^^^^^^^^^^^
 
 The :mod:`bigfloat` package works with Python 2 (version 2.7) or
-Python 3 (version 3.4 or later).  It uses a single codebase for both Python
+Python 3 (version 3.5 or later).  It uses a single codebase for both Python
 dialects, so the same source works on both dialects of Python.
 
 Whether installing ``bigfloat`` from source or from the Python Package Index,

--- a/fabfile.py
+++ b/fabfile.py
@@ -88,8 +88,9 @@ def docs(python=PYTHON):
 
 
 def test_all():
-    """Run tests on Python versions 2.7 and 3.4 through 3.6."""
+    """Run tests on Python versions 2.7 and 3.5 through 3.8."""
     test(python="python2.7")
-    test(python="python3.4")
     test(python="python3.5")
     test(python="python3.6")
+    test(python="python3.7")
+    test(python="python3.8")

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ idea::
 Features
 --------
 
-- Supports Python 2 (version 2.7) and Python 3 (version 3.4 or later).
+- Supports Python 2 (version 2.7) and Python 3 (version 3.5 or later).
 
 - Exactly reproducible correctly-rounded results across platforms;
   precisely-defined semantics compatible with the IEEE 754-2008 standard.
@@ -238,9 +238,10 @@ Operating System :: OS Independent
 Programming Language :: Python :: 2
 Programming Language :: Python :: 2.7
 Programming Language :: Python :: 3
-Programming Language :: Python :: 3.4
 Programming Language :: Python :: 3.5
 Programming Language :: Python :: 3.6
+Programming Language :: Python :: 3.7
+Programming Language :: Python :: 3.8
 Programming Language :: Python :: Implementation :: CPython
 Topic :: Scientific/Engineering :: Mathematics
 """.splitlines()


### PR DESCRIPTION
This PR drops Python 3.4 support (and makes some corresponding minor test code simplifications) and adds explicit support for 3.7 and 3.8.