### PR TITLE
Update copyright headers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -158,7 +158,7 @@ with suggestions, complaints, bug reports, etc.
 License
 -------
 
-The bigfloat package is copyright (C) 2009--2015 Mark Dickinson
+The bigfloat package is copyright (C) 2009--2019 Mark Dickinson
 
 The bigfloat package is free software: you can redistribute it and/or modify
 it under the terms of the GNU Lesser General Public License as published by

--- a/bigfloat/__init__.py
+++ b/bigfloat/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2009--2015 Mark Dickinson.
+# Copyright 2009--2019 Mark Dickinson.
 #
 # This file is part of the bigfloat package.
 #

--- a/bigfloat/context.py
+++ b/bigfloat/context.py
@@ -1,4 +1,4 @@
-# Copyright 2009--2015 Mark Dickinson.
+# Copyright 2009--2019 Mark Dickinson.
 #
 # This file is part of the bigfloat package.
 #

--- a/bigfloat/core.py
+++ b/bigfloat/core.py
@@ -1,6 +1,6 @@
 # -*- coding: UTF-8
 
-# Copyright 2009--2015 Mark Dickinson.
+# Copyright 2009--2019 Mark Dickinson.
 #
 # This file is part of the bigfloat package.
 #

--- a/bigfloat/formatting.py
+++ b/bigfloat/formatting.py
@@ -1,4 +1,4 @@
-# Copyright 2009--2015 Mark Dickinson.
+# Copyright 2009--2019 Mark Dickinson.
 #
 # This file is part of the bigfloat package.
 #

--- a/bigfloat/ieee.py
+++ b/bigfloat/ieee.py
@@ -1,4 +1,4 @@
-# Copyright 2009--2015 Mark Dickinson.
+# Copyright 2009--2019 Mark Dickinson.
 #
 # This file is part of the bigfloat package.
 #

--- a/bigfloat/mpfr_supplemental.py
+++ b/bigfloat/mpfr_supplemental.py
@@ -1,6 +1,6 @@
 # -*- coding: UTF-8
 
-# Copyright 2009--2015 Mark Dickinson.
+# Copyright 2009--2019 Mark Dickinson.
 #
 # This file is part of the bigfloat package.
 #

--- a/bigfloat/rounding_mode.py
+++ b/bigfloat/rounding_mode.py
@@ -1,4 +1,4 @@
-# Copyright 2009--2015 Mark Dickinson.
+# Copyright 2009--2019 Mark Dickinson.
 #
 # This file is part of the bigfloat package.
 #

--- a/bigfloat/test/__init__.py
+++ b/bigfloat/test/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2009--2015 Mark Dickinson.
+# Copyright 2009--2019 Mark Dickinson.
 #
 # This file is part of the bigfloat package.
 #

--- a/bigfloat/test/test_bigfloat.py
+++ b/bigfloat/test/test_bigfloat.py
@@ -1,4 +1,4 @@
-# Copyright 2009--2015 Mark Dickinson.
+# Copyright 2009--2019 Mark Dickinson.
 #
 # This file is part of the bigfloat package.
 #

--- a/bigfloat/test/test_context.py
+++ b/bigfloat/test/test_context.py
@@ -1,4 +1,4 @@
-# Copyright 2009--2015 Mark Dickinson.
+# Copyright 2009--2019 Mark Dickinson.
 #
 # This file is part of the bigfloat package.
 #

--- a/bigfloat/test/test_formatting.py
+++ b/bigfloat/test/test_formatting.py
@@ -1,4 +1,4 @@
-# Copyright 2009--2015 Mark Dickinson.
+# Copyright 2009--2019 Mark Dickinson.
 #
 # This file is part of the bigfloat package.
 #

--- a/bigfloat/test/test_mpfr.py
+++ b/bigfloat/test/test_mpfr.py
@@ -1,4 +1,4 @@
-# Copyright 2009--2015 Mark Dickinson.
+# Copyright 2009--2019 Mark Dickinson.
 #
 # This file is part of the bigfloat package.
 #

--- a/bigfloat/test/test_rounding_mode.py
+++ b/bigfloat/test/test_rounding_mode.py
@@ -1,4 +1,4 @@
-# Copyright 2009--2015 Mark Dickinson.
+# Copyright 2009--2019 Mark Dickinson.
 #
 # This file is part of the bigfloat package.
 #

--- a/bigfloat/version.py
+++ b/bigfloat/version.py
@@ -1,4 +1,4 @@
-# Copyright 2009--2015 Mark Dickinson.
+# Copyright 2009--2019 Mark Dickinson.
 #
 # This file is part of the bigfloat package.
 #

--- a/cgmp.pxd
+++ b/cgmp.pxd
@@ -1,4 +1,4 @@
-# Copyright 2009--2015 Mark Dickinson.
+# Copyright 2009--2019 Mark Dickinson.
 #
 # This file is part of the bigfloat package.
 #

--- a/cmpfr.pxd
+++ b/cmpfr.pxd
@@ -1,4 +1,4 @@
-# Copyright 2009--2015 Mark Dickinson.
+# Copyright 2009--2019 Mark Dickinson.
 #
 # This file is part of the bigfloat package.
 #

--- a/examples/contfrac.py
+++ b/examples/contfrac.py
@@ -1,19 +1,19 @@
-# Copyright 2009--2015 Mark Dickinson.
+# Copyright 2009--2019 Mark Dickinson.
 #
-# This file is part of the bigfloat module.
+# This file is part of the bigfloat package.
 #
-# The bigfloat module is free software: you can redistribute it and/or modify
+# The bigfloat package is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or (at your
 # option) any later version.
 #
-# The bigfloat module is distributed in the hope that it will be useful, but
+# The bigfloat package is distributed in the hope that it will be useful, but
 # WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
 # FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
 # for more details.
 #
 # You should have received a copy of the GNU Lesser General Public License
-# along with the bigfloat module.  If not, see <http://www.gnu.org/licenses/>.
+# along with the bigfloat package.  If not, see <http://www.gnu.org/licenses/>.
 
 """
 The documentation for mpfr_get_str, for converting a precision n

--- a/examples/lanczos_coeffs.py
+++ b/examples/lanczos_coeffs.py
@@ -1,19 +1,19 @@
-# Copyright 2009--2015 Mark Dickinson.
+# Copyright 2009--2019 Mark Dickinson.
 #
-# This file is part of the bigfloat module.
+# This file is part of the bigfloat package.
 #
-# The bigfloat module is free software: you can redistribute it and/or modify
+# The bigfloat package is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or (at your
 # option) any later version.
 #
-# The bigfloat module is distributed in the hope that it will be useful, but
+# The bigfloat package is distributed in the hope that it will be useful, but
 # WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
 # FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
 # for more details.
 #
 # You should have received a copy of the GNU Lesser General Public License
-# along with the bigfloat module.  If not, see <http://www.gnu.org/licenses/>.
+# along with the bigfloat package.  If not, see <http://www.gnu.org/licenses/>.
 
 # Computing the gamma function via Lanczos' formula
 #

--- a/mpfr.pyx
+++ b/mpfr.pyx
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # cython: embedsignature = True
 
-# Copyright 2009--2015 Mark Dickinson.
+# Copyright 2009--2019 Mark Dickinson.
 #
 # This file is part of the bigfloat package.
 #

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 # -*- coding: UTF-8
 
-# Copyright 2009--2015 Mark Dickinson.
+# Copyright 2009--2019 Mark Dickinson.
 #
 # This file is part of the bigfloat package.
 #
@@ -179,7 +179,7 @@ with suggestions, complaints, bug reports, etc.
 License
 -------
 
-The bigfloat package is copyright (C) 2009--2015 Mark Dickinson
+The bigfloat package is copyright (C) 2009--2019 Mark Dickinson
 
 The bigfloat package is free software: you can redistribute it and/or modify
 it under the terms of the GNU Lesser General Public License as published by


### PR DESCRIPTION
Update year range in copyright headers. Also makes a minor consistency fix, replacing uses of "bigfloat module" with "bigfloat package" in a small handful of headers (most headers already use the language "bigfloat package").