### PR TITLE
Prepare for the 0.4.0 release.

### DIFF
--- a/bigfloat/version.py
+++ b/bigfloat/version.py
@@ -18,7 +18,7 @@
 major = 0
 minor = 4
 patch = 0
-prerelease = 'dev'
+prerelease = ''
 
 if prerelease:
     __version__ = "{}.{}.{}-{}".format(major, minor, patch, prerelease)


### PR DESCRIPTION
[Note: PR is against the 0.4.x release branch]

Bump version number for 0.4.0 release.