### PR TITLE
Fix initialisation of thread-local context

### DIFF
--- a/bigfloat/context.py
+++ b/bigfloat/context.py
@@ -197,21 +197,26 @@ WideExponentContext = Context(
 )
 
 
-# thread local variables:
+# thread-local variables:
 #   __bigfloat_context__: current context
 #   __context_stack__: context stack, used by with statement
 
 local = threading.local()
-local.__bigfloat_context__ = DefaultContext
-local.__context_stack__ = []
 
 
 def getcontext(_local=local):
     """
     Return the current context.
 
+    Also initialises the context the first time it's called in each thread.
+
     """
-    return _local.__bigfloat_context__
+    try:
+        return _local.__bigfloat_context__
+    except AttributeError:
+        _local.__bigfloat_context__ = DefaultContext
+        _local.__context_stack__ = []
+        return _local.__bigfloat_context__
 
 
 def setcontext(context, _local=local):
@@ -236,6 +241,7 @@ def _popcontext(_local=local):
     setcontext(_local.__context_stack__.pop())
 
 
+# Don't contaminate the namespace.
 del threading, local
 
 

--- a/bigfloat/context.py
+++ b/bigfloat/context.py
@@ -214,9 +214,8 @@ def getcontext(_local=local):
     try:
         return _local.__bigfloat_context__
     except AttributeError:
-        _local.__bigfloat_context__ = DefaultContext
-        _local.__context_stack__ = []
-        return _local.__bigfloat_context__
+        context = _local.__bigfloat_context__ = DefaultContext
+        return context
 
 
 def setcontext(context, _local=local):
@@ -233,11 +232,18 @@ def setcontext(context, _local=local):
 
 
 def _pushcontext(context, _local=local):
-    _local.__context_stack__.append(getcontext())
+    try:
+        context_stack = _local.__context_stack__
+    except AttributeError:
+        context_stack = _local.__context_stack__ = []
+    context_stack.append(getcontext())
     setcontext(context)
 
 
 def _popcontext(_local=local):
+    # It's safe to assume that __context_stack__ is already initialised and
+    # non-empty here, since any _popcontext call will have been preceded by a
+    # corresponding _pushcontext call.
     setcontext(_local.__context_stack__.pop())
 
 


### PR DESCRIPTION
Ensure that the thread-local context is created properly for background threads, and not just for the main thread.

Fixes #78.

There's a known test failure, likely due to some other test changing the context and not restoring the original (the test added in this PR runs fine by itself, but not as part of the suite). I'll track that down and fix it in a separate PR.