### PR TITLE
Use language_level=3 in Cython code (backport of #96)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -60,6 +60,11 @@ Bugfixes
 
 - Fix unit tests that changed the context and didn't reset their changes. (#92)
 
+Build
+-----
+
+- Use ``language_level=3`` in the Cython code. (#96)
+
 Documentation
 -------------
 

--- a/mpfr.pyx
+++ b/mpfr.pyx
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# cython: embedsignature = True
+# cython: language_level=3, embedsignature=True
 
 # Copyright 2009--2019 Mark Dickinson.
 #


### PR DESCRIPTION
Backport of PR #96 (using `language_level=3` in Cython code) to the release branch.