### PR TITLE
Fix TestFormatting to undo its context changes (#98)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -58,7 +58,8 @@ Bugfixes
 
 - Fix initialization of the context on background threads. (#91)
 
-- Fix unit tests that changed the context and didn't reset their changes. (#92)
+- Fix unit tests that changed the context and didn't reset their changes.
+  (#92, #98)
 
 Build
 -----

--- a/bigfloat/test/test_formatting.py
+++ b/bigfloat/test/test_formatting.py
@@ -21,6 +21,7 @@ from bigfloat import (
     BigFloat,
     double_precision,
     RoundTiesToEven,
+    getcontext,
     setcontext,
 )
 
@@ -30,7 +31,12 @@ DefaultTestContext = double_precision + RoundTiesToEven
 
 class TestFormatting(unittest.TestCase):
     def setUp(self):
+        self._original_context = getcontext()
         setcontext(DefaultTestContext)
+
+    def tearDown(self):
+        setcontext(self._original_context)
+        del self._original_context
 
     def test_format(self):
         # Fixed precision formatting.


### PR DESCRIPTION
(cherry picked from commit 516c02815e837c380207827b497978d09baed09e)

Backport of #98 from the master branch to the release branch