### PR TITLE
Add wrapper for mpfr_sum

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,9 +56,9 @@ For demonstration purposes, start with::
     >>> from bigfloat import *
 
 Note that this import shadows some builtin Python functions, namely ``abs``,
-``max``, ``min``, ``pow``, ``round`` and (on Python 2 only) ``cmp``.  In normal
-usage you'll probably only want to import the classes and functions that you
-actually need.
+``max``, ``min``, ``pow``, ``round``, ``sum`` and (on Python 2 only) ``cmp``.
+In normal usage you'll probably only want to import the classes and functions
+that you actually need.
 
 The main class is the ``BigFloat`` class::
 

--- a/bigfloat/__init__.py
+++ b/bigfloat/__init__.py
@@ -94,6 +94,7 @@ __all__ = [
     'hypot',
     'ai',
     'const_log2', 'const_pi', 'const_euler', 'const_catalan',
+    'sum',
 
     # 5.10 Integer and Remainder Related Functions
     'ceil', 'floor', 'round', 'roundeven', 'trunc',
@@ -171,6 +172,7 @@ from bigfloat.core import (
     hypot,
     ai,
     const_log2, const_pi, const_euler, const_catalan,
+    sum,
 
     # 5.10 Integer and Remainder Related Functions
     ceil, floor, round, roundeven, trunc,

--- a/bigfloat/core.py
+++ b/bigfloat/core.py
@@ -2468,6 +2468,34 @@ def const_catalan(context=None):
     )
 
 
+def sum(elements, context=None):
+    """
+    Return the sum of the given elements.
+
+    Returns the sum of the iterable elements, with precision and rounding
+    mode taken from the current context.
+
+    If no elements are given (the iterable is empty), the result is a
+    (positive) zero. If the iterable contains just one element, the result
+    is equivalent to applying :func:`pos` to that element.
+
+    If the exact sum is zero and there is at least one element in the
+    iterable, the sign is determined as follows:
+
+    - If all inputs have the same sign, the result has the same sign as the
+      inputs.
+    - Otherwise, the result is +0, except with rounding mode
+      ``RoundTowardNegative``, when it's -0.
+
+    """
+    return _apply_function_in_current_context(
+        BigFloat,
+        mpfr.mpfr_sum,
+        ([BigFloat._implicit_convert(x) for x in elements],),
+        context,
+    )
+
+
 ###############################################################################
 # 5.10 Integer and Remainder Related Functions
 ###############################################################################

--- a/bigfloat/test/test_mpfr.py
+++ b/bigfloat/test/test_mpfr.py
@@ -176,6 +176,8 @@ from mpfr import (
     mpfr_free_cache2,
     mpfr_free_pool,
 
+    mpfr_sum,
+
     # 5.10 Integer and Remainder Related Functions
     mpfr_rint,
     mpfr_ceil,
@@ -1485,6 +1487,38 @@ class TestMpfr(unittest.TestCase):
         # It's awkward to test this; we settle for checking that the function
         # has been exported and is callable.
         mpfr_free_pool()
+
+    def test_sum(self):
+        x = Mpfr(53)
+        one = Mpfr(53)
+        mpfr_set_d(one, 1.0, MPFR_RNDN)
+        two = Mpfr(53)
+        mpfr_set_d(two, 2.0, MPFR_RNDN)
+        uninitialized = Mpfr_t()
+
+        # Sum of an empty list.
+        mpfr_sum(x, [], MPFR_RNDN)
+        self.assertEqual(mpfr_get_d(x, MPFR_RNDN), 0.0)
+
+        # Sum of a single element.
+        mpfr_sum(x, [one], MPFR_RNDN)
+        self.assertEqual(mpfr_get_d(x, MPFR_RNDN), 1.0)
+
+        # Sum of multiple elements.
+        mpfr_sum(x, [one, two, one, two], MPFR_RNDN)
+        self.assertEqual(mpfr_get_d(x, MPFR_RNDN), 6.0)
+
+        # Failure case: None in list.
+        with self.assertRaises(TypeError):
+            mpfr_sum(x, [one, None], MPFR_RNDN)
+
+        # Failure case: elements not convertible to Mpfr_t in list.
+        with self.assertRaises(TypeError):
+            mpfr_sum(x, [one, 2.0], MPFR_RNDN)
+
+        # Failure case: uninitialised elements.
+        with self.assertRaises(ValueError):
+            mpfr_sum(x, [one, uninitialized], MPFR_RNDN)
 
     # 5.10 Integer and Remainder Related Functions
     def test_rint(self):

--- a/cmpfr.pxd
+++ b/cmpfr.pxd
@@ -262,6 +262,11 @@ cdef extern from "mpfr.h":
     void mpfr_free_cache2(mpfr_free_cache_t way)
     void mpfr_free_pool()
 
+    int mpfr_sum(
+        mpfr_ptr rop, const mpfr_ptr tab[], unsigned long int n,
+        mpfr_rnd_t rnd
+    )
+
     ###########################################################################
     # 5.9 Formatted Output Functions
     ###########################################################################

--- a/docs/source/reference/coverage.rst
+++ b/docs/source/reference/coverage.rst
@@ -462,5 +462,5 @@ is used by :func:`mpfr.mpfr_get_str`, but is not exposed to Python.
 +------------------------+------------------------+
 | mpfr_mp_memory_cleanup | not implemented        |
 +------------------------+------------------------+
-| mpfr_sum               | not implemented        |
+| mpfr_sum               | wrapped                |
 +------------------------+------------------------+

--- a/docs/source/reference/index.rst
+++ b/docs/source/reference/index.rst
@@ -501,6 +501,8 @@ Arithmetic functions
 .. autofunction:: rootn
 .. autofunction:: hypot
 
+.. autofunction:: sum
+
 
 Exponential and logarithmic functions
 """""""""""""""""""""""""""""""""""""

--- a/docs/source/tutorial/index.rst
+++ b/docs/source/tutorial/index.rst
@@ -10,8 +10,9 @@ Start by importing the contents of the package with:
 You should be a little bit careful here: this import brings a fairly large
 number of functions into the current namespace, some of which shadow existing
 Python builtins, namely :func:`abs`, :func:`max`, :func:`min`, :func:`pow`,
-:func:`round`, and (on Python 2 only) :func:`cmp`.  In normal usage you'll
-probably only want to import the classes and functions that you actually need.
+:func:`round`, :func:`sum`, and (on Python 2 only) :func:`cmp`.  In normal
+usage you'll probably only want to import the classes and functions that you
+actually need.
 
 
 :class:`BigFloat` construction

--- a/mpfr.pyx
+++ b/mpfr.pyx
@@ -3216,7 +3216,8 @@ def mpfr_erangeflag_p():
 #
 # The following are not yet implemented.
 #
-#  mpfr_sum
+#  mpfr_log_ui
+#  mpfr_mp_memory_cleanup
 #
 #
 #  5.8 Input and Output Functions

--- a/mpfr.pyx
+++ b/mpfr.pyx
@@ -18,6 +18,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with the bigfloat package.  If not, see <http://www.gnu.org/licenses/>.
 
+cimport libc.stdlib
+
 cimport cmpfr
 
 import sys
@@ -2025,6 +2027,48 @@ def mpfr_free_pool():
     """
     cmpfr.mpfr_free_pool()
 
+def mpfr_sum(Mpfr_t rop not None, tab, cmpfr.mpfr_rnd_t rnd):
+    """
+    Set rop to the sum of the elements of tab, rounded in the direction rnd.
+
+    Set rop to the sum of all elements of tab, correctly rounded in the
+    direction rnd. If tab is empty, then the result is +0, and if tab contains
+    a single element, then the function is equivalent to mpfr_set. For the
+    special exact cases, the result is the same as the one obtained with a
+    succession of additions (mpfr_add) in infinite precision. In particular, if
+    the result is an exact zero and tab is not empty:
+
+    - if all the inputs have the same sign (i.e., all +0 or all -0), then the
+      result has the same sign as the inputs;
+
+    - otherwise, either because all inputs are zeros with at least a +0 and a
+      -0, or because some inputs are non-zero (but they globally cancel), the
+      result is +0, except for the MPFR_RNDD rounding mode, where it is -0.
+
+    """
+    cdef unsigned int i, n
+    cdef Mpfr_t elt
+
+    check_initialized(rop)
+    check_rounding_mode(rnd)
+
+    n = len(tab)
+
+    cdef cmpfr.mpfr_ptr *pointers = <cmpfr.mpfr_ptr *> libc.stdlib.malloc(
+        n * sizeof(cmpfr.mpfr_ptr))
+    if not pointers:
+        raise MemoryError
+
+    try:
+        for i in range(n):
+            elt = tab[i]
+            if elt is None:
+                raise TypeError("Cannot convert None to mpfr.Mpfr_t")
+            check_initialized(elt)
+            pointers[i] = &elt._value
+        return cmpfr.mpfr_sum(&rop._value, pointers, n, rnd)
+    finally:
+        libc.stdlib.free(pointers)
 
 ###########################################################################
 # 5.9 Formatted Output Functions


### PR DESCRIPTION
This PR (against the MPFR 4 update branch) adds a wrapper for `mpfr_sum`.

I'm expecting the CI to fail: I haven't yet re-introduced backward compatibility for MPFR 3.x, and Xenial doesn't have MPFR 4.