### PR TITLE
Update .gitignore to ignore built .so for Python 3.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ __pycache__/
 
 # Cython output.
 mpfr.c
-mpfr.so
+mpfr*.so
 
 # Build output (covers docs and extension build)
 build/


### PR DESCRIPTION
Under Python 3, the built `.so` has a name resembling `mpfr.cpython-38-darwin.so`. Update `.gitignore` to cover this case.