### PR TITLE
Wrap new flag functions and macros

### DIFF
--- a/cmpfr.pxd
+++ b/cmpfr.pxd
@@ -25,6 +25,7 @@ cdef extern from "mpfr.h":
     # MPFR type declarations
     ctypedef int mpfr_prec_t
     ctypedef int mpfr_sign_t
+    ctypedef unsigned int mpfr_flags_t
     ctypedef cgmp.mp_exp_t mpfr_exp_t
 
     ctypedef struct __mpfr_struct:
@@ -59,6 +60,15 @@ cdef extern from "mpfr.h":
 
     mpfr_exp_t MPFR_EMIN_DEFAULT
     mpfr_exp_t MPFR_EMAX_DEFAULT
+
+    # Flags
+    mpfr_flags_t MPFR_FLAGS_UNDERFLOW
+    mpfr_flags_t MPFR_FLAGS_OVERFLOW
+    mpfr_flags_t MPFR_FLAGS_NAN
+    mpfr_flags_t MPFR_FLAGS_INEXACT
+    mpfr_flags_t MPFR_FLAGS_ERANGE
+    mpfr_flags_t MPFR_FLAGS_DIVBY0
+    mpfr_flags_t MPFR_FLAGS_ALL
 
 
     ###########################################################################
@@ -346,3 +356,9 @@ cdef extern from "mpfr.h":
     int mpfr_nanflag_p()
     int mpfr_inexflag_p()
     int mpfr_erangeflag_p()
+
+    void mpfr_flags_clear(mpfr_flags_t mask)
+    void mpfr_flags_set(mpfr_flags_t mask)
+    mpfr_flags_t mpfr_flags_test(mpfr_flags_t mask)
+    mpfr_flags_t mpfr_flags_save()
+    void mpfr_flags_restore(mpfr_flags_t flags, mpfr_flags_t mask)

--- a/mpfr.pyx
+++ b/mpfr.pyx
@@ -51,6 +51,15 @@ MPFR_RNDA =  cmpfr.MPFR_RNDA
 MPFR_EMAX_DEFAULT = cmpfr.MPFR_EMAX_DEFAULT
 MPFR_EMIN_DEFAULT = cmpfr.MPFR_EMIN_DEFAULT
 
+# Make flag values available to Python
+MPFR_FLAGS_UNDERFLOW = cmpfr.MPFR_FLAGS_UNDERFLOW
+MPFR_FLAGS_OVERFLOW = cmpfr.MPFR_FLAGS_OVERFLOW
+MPFR_FLAGS_NAN = cmpfr.MPFR_FLAGS_NAN
+MPFR_FLAGS_INEXACT = cmpfr.MPFR_FLAGS_INEXACT
+MPFR_FLAGS_ERANGE = cmpfr.MPFR_FLAGS_ERANGE
+MPFR_FLAGS_DIVBY0 = cmpfr.MPFR_FLAGS_DIVBY0
+MPFR_FLAGS_ALL = cmpfr.MPFR_FLAGS_ALL
+
 
 ###############################################################################
 # Helper functions, not exposed to Python
@@ -2794,6 +2803,42 @@ def mpfr_erangeflag_p():
     """
     return bool(cmpfr.mpfr_erangeflag_p())
 
+def mpfr_flags_clear(cmpfr.mpfr_flags_t mask):
+    """
+    Clear (lower) the group of flags specified by mask.
+
+    """
+    cmpfr.mpfr_flags_clear(mask)
+
+def mpfr_flags_set(cmpfr.mpfr_flags_t mask):
+    """
+    Set (raise) the group of flags specified by mask.
+
+    """
+    cmpfr.mpfr_flags_set(mask)
+
+def mpfr_flags_test(cmpfr.mpfr_flags_t mask):
+    """
+    Return the flags specified by mask.
+
+    """
+    return cmpfr.mpfr_flags_test(mask)
+
+def mpfr_flags_save():
+    """
+    Return all the flags. This is equivalent to mpfr_flags_test(MPFR_FLAGS_ALL)
+
+    """
+    return cmpfr.mpfr_flags_save()
+
+def mpfr_flags_restore(cmpfr.mpfr_flags_t flags, cmpfr.mpfr_flags_t mask):
+    """
+    Set the current flag state from an integer.
+
+    Restore the flags specified by mask to their state represented in flags.
+
+    """
+    cmpfr.mpfr_flags_restore(flags, mask)
 
 
 # Functions that are documented in the MPFR 3.0.1 documentation, but aren't


### PR DESCRIPTION
- Wrap new `mpfr_flags_*` functions, which operate on collections of flags
- Expose the `MPFR_FLAGS_*` constants to Python
- Test reproducibility: ensure that each test in `TestMpfr` restores the flag state on tearDown, and presents a clear set of flags for the test.